### PR TITLE
Fix Issue #64: User injected messages not receiving proper responses

### DIFF
--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -2071,8 +2071,9 @@ function DeepgramVoiceInteraction(
         lazyLog(`🔍 [connectWithContext] Agent WebSocket already connected (${currentState})`);
       }
       
-      // Send settings with conversation context only if not already sent
-      if (agentManagerRef.current && !state.hasSentSettings) {
+      // Send settings with conversation context for lazy reconnection
+      // Always send settings during lazy reconnection to ensure proper context
+      if (agentManagerRef.current) {
         const settingsMessage = {
           type: 'Settings',
           audio: {
@@ -2114,7 +2115,8 @@ function DeepgramVoiceInteraction(
                 model: options.voice || 'aura-asteria-en'
               }
             },
-            greeting: options.greeting,
+            // Don't include greeting for lazy reconnection - we're resuming a conversation, not starting new
+            // greeting: options.greeting,
             context: transformConversationHistory(history) // Include conversation context in correct Deepgram API format
           }
         };
@@ -2128,8 +2130,6 @@ function DeepgramVoiceInteraction(
         (window as any).globalSettingsSent = true;
         settingsSentTimeRef.current = Date.now();
         lazyLog('Settings sent with conversation context (correct Deepgram API format)');
-      } else if (state.hasSentSettings) {
-        lazyLog('Settings already sent, skipping duplicate');
       }
       
       lazyLog('Successfully connected with conversation context');

--- a/tests/context-preservation-validation.test.js
+++ b/tests/context-preservation-validation.test.js
@@ -93,7 +93,8 @@ describe('Context Preservation Validation', () => {
           speak: {
             provider: { type: 'deepgram', model: 'aura-asteria-en' }
           },
-          greeting: options.greeting,
+          // Don't include greeting for lazy reconnection - we're resuming a conversation, not starting new
+          // greeting: options.greeting,
           context: transformConversationHistory(history) // Correct Deepgram API format
         }
       };
@@ -201,7 +202,8 @@ describe('Context Preservation Validation', () => {
           speak: {
             provider: { type: 'deepgram', model: 'aura-asteria-en' }
           },
-          greeting: options.greeting,
+          // Don't include greeting for lazy reconnection - we're resuming a conversation, not starting new
+          // greeting: options.greeting,
           context: transformConversationHistory(history) // Correct Deepgram API format
         }
       };
@@ -295,8 +297,9 @@ describe('Context Preservation Validation', () => {
           },
           speak: {
             provider: { type: 'deepgram', model: 'aura-asteria-en' }
-          },
-          greeting: options.greeting
+          }
+          // Don't include greeting for lazy reconnection - we're resuming a conversation, not starting new
+          // greeting: options.greeting
           // context: history // COMMENTED OUT - This was the problem!
         }
       };
@@ -378,7 +381,8 @@ describe('Context Preservation Validation', () => {
           speak: {
             provider: { type: 'deepgram', model: 'aura-asteria-en' }
           },
-          greeting: options.greeting,
+          // Don't include greeting for lazy reconnection - we're resuming a conversation, not starting new
+          // greeting: options.greeting,
           context: history // FIXED: Context is now included!
         }
       };


### PR DESCRIPTION
## Problem
User injected messages were not being processed correctly by the agent. Instead of responding to the actual user input, the agent was sending built-in greeting messages ("Hello! How can I assist you today?") repeatedly.

## Root Cause Analysis
1. **Greeting Response Issue**: The `connectWithContext` method was including the `greeting` field in settings for lazy reconnection, causing the agent to send greeting messages instead of processing user input.
2. **Multiple Reconnection Issue**: The `connectWithContext` method was checking `state.hasSentSettings` and skipping settings sending on subsequent reconnections, even though the state wasn't properly reset.

## Solution
1. **Remove greeting from lazy reconnection settings**: Commented out `greeting: options.greeting` in the `connectWithContext` method since we're resuming a conversation, not starting a new one.
2. **Always send settings during lazy reconnection**: Modified the condition to always send settings during lazy reconnection to ensure proper context is maintained for every reconnection.

## Changes Made
- **`src/components/DeepgramVoiceInteraction/index.tsx`**:
  - Removed greeting from settings in `connectWithContext` method
  - Changed condition to always send settings during lazy reconnection
  - Removed the `else if` clause that was skipping settings on subsequent reconnections
- **`tests/context-preservation-validation.test.js`**:
  - Updated test simulations to reflect the greeting removal fix

## Testing
- ✅ All existing lazy reconnection tests pass
- ✅ All context preservation tests pass
- ✅ Verified that initial connections still include greetings (as expected)
- ✅ Verified that lazy reconnections don't include greetings (as intended)
- ✅ Confirmed multiple reconnections now work properly

## Impact
- Fixes the core issue where user messages were receiving greeting responses instead of proper agent responses
- Ensures all reconnections work correctly with full conversation context
- Maintains backward compatibility
- No breaking changes to existing functionality

Closes #64