### PR TITLE
feat: Move VAD and keepalive debug logs to debug mode only

### DIFF
--- a/test-app/src/App.tsx
+++ b/test-app/src/App.tsx
@@ -82,15 +82,20 @@ function App() {
     // Don't clear keepalive - let it persist in the log history
   }, []); // No dependencies, created once
   
+  // Get debug state from URL or environment
+  const isDebugMode = import.meta.env.VITE_DEBUG === 'true' || new URLSearchParams(window.location.search).get('debug') === 'true' || false;
+  
   // Helper to update keepalive - memoized
   const updateKeepalive = useCallback((message: string) => {
     const timestampedMessage = `${new Date().toISOString().substring(11, 19)} - ${message}`;
     setCurrentKeepalive(timestampedMessage);
     // Add to logs so it persists (this replaces the current keepalive in the display)
     setLogs(prev => [...prev, timestampedMessage]);
-    // Also log to console for debugging
-    console.log(timestampedMessage);
-  }, []); // No dependencies, created once
+    // Only log to console when debug mode is enabled
+    if (isDebugMode) {
+      console.log(timestampedMessage);
+    }
+  }, [isDebugMode]); // Include isDebugMode in dependencies
   
   // Memoize options objects to prevent unnecessary re-renders/effect loops
   const memoizedTranscriptionOptions = useMemo(() => ({
@@ -623,7 +628,7 @@ VITE_DEEPGRAM_PROJECT_ID=your-real-project-id
         // onSpeechStopped removed - not a real Deepgram event
         onUtteranceEnd={handleUtteranceEnd}
         onVADEvent={handleVADEvent}
-        debug={import.meta.env.VITE_DEBUG === 'true' || new URLSearchParams(window.location.search).get('debug') === 'true' || false} // Enable debug via environment variable or URL parameter for testing
+        debug={isDebugMode} // Enable debug via environment variable or URL parameter for testing
       />
       
       <div style={{ border: '1px solid blue', padding: '10px', margin: '15px 0' }}>


### PR DESCRIPTION
## 🐛 Issue Description

Debug logs were showing unexpected VAD event type "History" and keepalive messages that should only appear when debug mode is enabled, making user-facing logs cluttered.

## ✅ Changes Made

### VAD Debug Logs
- Moved VAD event type checking debug log to only show when `props.debug` is enabled
- Moved all VAD-related debug logs to debug mode only:
  - VAD event received logs
  - VAD state change logs (speechDetected true/false)
  - UtteranceEnd and SpeechStarted debug logs
  - VAD configuration logs
  - VAD connection logs

### Keepalive Debug Logs
- Modified `updateKeepalive` function in test app to only log to console when debug mode is enabled
- Keepalive messages still appear in UI logs for user visibility
- Added consistent debug mode detection using environment variables and URL parameters

### Code Quality
- Standardized all debug logging to use `props.debug` consistently
- Fixed inconsistent debug variable usage throughout component
- Updated WebSocketManager and AudioManager constructors to use `props.debug`

## 🎯 Result

- **Cleaner user-facing logs**: Debug messages no longer clutter console when debug is disabled
- **Preserved debug functionality**: Developers can still access detailed information with `?debug=true` or `VITE_DEBUG=true`
- **Consistent behavior**: All debug logs follow the same pattern and are properly controlled

## 🧪 Testing

- Created and ran tests to verify debug logs only appear when debug mode is enabled
- Confirmed VAD event type "History" debug log is properly controlled
- Verified keepalive logs are only shown in console when debug is enabled

## 📝 Files Modified

- `src/components/DeepgramVoiceInteraction/index.tsx` - Main component debug logging
- `test-app/src/App.tsx` - Test app keepalive logging

Resolves #138