### PR TITLE
Remove onKeepalive callback prop and fix keepalive logging

### DIFF
--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -145,7 +145,6 @@ function DeepgramVoiceInteraction(
     onUserStartedSpeaking,
     onUserStoppedSpeaking,
     onUtteranceEnd,
-    onKeepalive,
     onPlaybackStateChange,
     onError,
     // Auto-connect dual mode props
@@ -695,9 +694,6 @@ function DeepgramVoiceInteraction(
         } else if (event.state === 'connected' && autoConnect) {
           log('Connection established but auto-connect will handle settings sending, skipping');
         }
-      } else if (event.type === 'keepalive') {
-        // Keepalive events are no longer logged to reduce noise
-        onKeepalive?.(event.data.service);
       } else if (event.type === 'message') {
         handleAgentMessage(event.data);
       } else if (event.type === 'binary') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,10 +126,6 @@ export interface DeepgramVoiceInteractionProps {
    */
   onUserStartedSpeaking?: () => void;
   
-  /**
-   * Called when a keepalive message is sent (for logging purposes)
-   */
-  onKeepalive?: (service: ServiceType) => void;
   
   
   /**

--- a/src/utils/websocket/WebSocketManager.ts
+++ b/src/utils/websocket/WebSocketManager.ts
@@ -396,15 +396,17 @@ export class WebSocketManager {
    */
   private sendKeepalive(): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      // Emit keepalive event for test-app logging (but don't log to console)
-      this.emit({ 
-        type: 'keepalive', 
-        data: { 
-          type: 'KeepAlive', 
-          timestamp: Date.now(),
-          service: this.options.service 
-        } 
-      });
+      // Only emit keepalive events in debug mode to reduce noise
+      if (this.options.debug) {
+        this.emit({ 
+          type: 'keepalive', 
+          data: { 
+            type: 'KeepAlive', 
+            timestamp: Date.now(),
+            service: this.options.service 
+          } 
+        });
+      }
       
       try {
         this.ws.send(JSON.stringify({ type: 'KeepAlive' }));

--- a/test-app/src/App.tsx
+++ b/test-app/src/App.tsx
@@ -43,7 +43,6 @@ function App() {
     agent: 'closed'
   });
   const [logs, setLogs] = useState<string[]>([]);
-  const [currentKeepalive, setCurrentKeepalive] = useState<string | null>(null);
   const [micLoading, setMicLoading] = useState(false);
   
   // Instructions state
@@ -99,18 +98,6 @@ function App() {
   
   // Get debug state from URL or environment
   const isDebugMode = import.meta.env.VITE_DEBUG === 'true' || new URLSearchParams(window.location.search).get('debug') === 'true' || false;
-  
-  // Helper to update keepalive - memoized
-  const updateKeepalive = useCallback((message: string) => {
-    const timestampedMessage = `${new Date().toISOString().substring(11, 19)} - ${message}`;
-    setCurrentKeepalive(timestampedMessage);
-    // Add to logs so it persists (this replaces the current keepalive in the display)
-    setLogs(prev => [...prev, timestampedMessage]);
-    // Only log to console when debug mode is enabled
-    if (isDebugMode) {
-      console.log(timestampedMessage);
-    }
-  }, [isDebugMode]); // Include isDebugMode in dependencies
   
   // Memoize options objects to prevent unnecessary re-renders/effect loops
   const memoizedTranscriptionOptions = useMemo(() => ({
@@ -647,7 +634,6 @@ VITE_DEEPGRAM_PROJECT_ID=your-real-project-id
         onConnectionStateChange={handleConnectionStateChange}
         onError={handleError}
         onPlaybackStateChange={handlePlaybackStateChange}
-        onKeepalive={(service) => updateKeepalive(`💓 [KEEPALIVE] ${service} keepalive sent`)}
         // Auto-connect dual mode props
         autoConnect={true}
         microphoneEnabled={micEnabled}
@@ -1003,9 +989,9 @@ VITE_DEEPGRAM_PROJECT_ID=your-real-project-id
 
       <div data-testid="event-log" style={{ marginTop: '20px', border: '1px solid #4a5568', padding: '10px', pointerEvents: 'auto', backgroundColor: '#1a202c' }}>
         <h3 style={{ color: '#e2e8f0' }}>Event Log</h3>
-        <button onClick={() => { setLogs([]); setCurrentKeepalive(null); }} style={{ marginBottom: '10px', pointerEvents: 'auto', backgroundColor: '#4a5568', color: '#e2e8f0', border: '1px solid #2d3748', padding: '5px 10px', borderRadius: '4px' }}>Clear Logs</button>
+        <button onClick={() => { setLogs([]); }} style={{ marginBottom: '10px', pointerEvents: 'auto', backgroundColor: '#4a5568', color: '#e2e8f0', border: '1px solid #2d3748', padding: '5px 10px', borderRadius: '4px' }}>Clear Logs</button>
         <pre style={{ maxHeight: '300px', overflowY: 'scroll', background: '#2d3748', padding: '5px', color: '#e2e8f0', border: '1px solid #4a5568', borderRadius: '4px' }}>
-          {currentKeepalive ? [currentKeepalive, ...logs.slice().reverse()].join('\n') : logs.slice().reverse().join('\n')}
+          {logs.slice().reverse().join('\n')}
         </pre>
       </div>
     </div>


### PR DESCRIPTION
## Summary

This PR removes the `onKeepalive` callback prop and fixes keepalive message logging behavior to resolve both Issue #156 and Issue #169.

## Changes Made

### Issue #156 - Remove onKeepalive Callback
- ✅ Removed `onKeepalive` prop from `DeepgramVoiceInteractionProps` interface
- ✅ Removed keepalive callback handling from component implementation
- ✅ Removed `onKeepalive` usage from test-app
- ✅ Cleaned up keepalive-related state and functions

### Issue #169 - Fix Keepalive Logging
- ✅ Modified `WebSocketManager.sendKeepalive()` to only emit keepalive events in debug mode
- ✅ Keepalive messages now only appear in debug logs, not Event Log
- ✅ Resolves Event Log noise during normal operation

## Benefits

- **Cleaner API**: Removes unnecessary prop that provided no developer value
- **Reduced Complexity**: Less interface surface area
- **Fixed Event Log Noise**: Keepalive messages only appear when debug mode is enabled
- **Maintained Functionality**: Internal keepalive handling remains unchanged

## Migration Path

**Before:**
```tsx
<DeepgramVoiceInteraction
  onKeepalive={(service) => console.log('Keepalive:', service)}
/>
```

**After:**
```tsx
<DeepgramVoiceInteraction
  debug={true} // Enable debug logging if needed
/>
```

## Testing

- ✅ All existing tests pass
- ✅ No linter errors
- ✅ Build process successful
- ✅ TypeScript compilation successful

## Breaking Change

This is a breaking change - existing code using `onKeepalive` will need to be updated. However, the prop was optional, so existing code won't break immediately but should be cleaned up.

Resolves #156 and #169