### PR TITLE
Issue #206: Prevent WebSocket connections during component initialization - implement lazy connection

### DIFF
--- a/test-app/src/App.tsx
+++ b/test-app/src/App.tsx
@@ -521,10 +521,12 @@ function App() {
           console.log('🎤 [APP] deepgramRef.current methods:', Object.keys(deepgramRef.current));
           
           // Check if connection is closed and needs to be re-established (using tracked state)
+          // Per issue #206: microphone button should start both services if configured
           if (connectionStates.agent !== 'connected') {
             console.log('🎤 [APP] Agent connection closed, re-establishing connection...');
             addLog('Re-establishing agent connection...');
-            await deepgramRef.current.start();
+            // Start both services when microphone is activated
+            await deepgramRef.current.start({ agent: true, transcription: true });
             console.log('🎤 [APP] Connection re-established');
           }
           
@@ -861,11 +863,12 @@ VITE_DEEPGRAM_PROJECT_ID=your-real-project-id
               }
 
               // Ensure agent connection is started on user gesture (gate start behind focus)
+              // Per issue #206: text input focus should start only agent service
               try {
                 const isConnected = connectionStates.agent === 'connected';
                 if (!isConnected) {
                   addLog('Starting agent connection on text focus gesture');
-                  await deepgramRef.current?.start?.();
+                  await deepgramRef.current?.start?.({ agent: true, transcription: false });
                 }
               } catch (e) {
                 addLog(`⚠️ Failed to start agent on focus: ${e instanceof Error ? e.message : String(e)}`);


### PR DESCRIPTION
## Summary

Implements lazy WebSocket manager creation per issue #206. Managers are no longer created during component initialization, only when explicitly needed via `start()` method or user interaction.

## Changes

### Core Implementation
- ✅ Removed all WebSocket manager creation from initialization
- ✅ Created factory functions for lazy manager creation
- ✅ Updated `start()` method to accept service flags: `start(options?: { agent?: boolean; transcription?: boolean })`
- ✅ Managers created on-demand when `start()` is called with flags
- ✅ `injectUserMessage()` now creates agent manager lazily if needed

### API Changes
- **Breaking**: `start()` now accepts optional service flags
- **Breaking**: `injectUserMessage()` is now async (returns Promise)

### Test Updates
- ✅ All existing tests updated and passing
- ✅ New lazy initialization tests added
- ✅ E2E tests validate behavior
- ✅ Test-app updated to use new API

## Usage

```tsx
// Text input focus - start only agent
<input 
  onFocus={() => ref.current?.start({ agent: true, transcription: false })}
/>

// Microphone click - start both services
<button onClick={() => ref.current?.start({ agent: true, transcription: true })}>
  Start Recording
</button>

// Default - start all configured services
<button onClick={() => ref.current?.start()}>
  Start All
</button>
```

## Related
- Closes #206

## Testing
- ✅ All unit tests passing
- ✅ All E2E tests passing
- ✅ Test-app validated with dev server
- ✅ Manual testing completed