### PR TITLE
Fix Issue #234: Omit greeting when context with messages is provided

### DIFF
--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -1146,7 +1146,12 @@ function DeepgramVoiceInteraction(
             model: agentOptions.voice || 'aura-asteria-en'
           }
         },
-        greeting: agentOptions.greeting,
+        // Issue #234: Only include greeting if context is not provided or context.messages is empty
+        // When context with existing messages is provided, this is a reconnection and greeting should be omitted
+        // to avoid duplicate greeting on reconnection
+        ...(agentOptions.context?.messages && agentOptions.context.messages.length > 0 
+          ? {} 
+          : { greeting: agentOptions.greeting }),
         context: agentOptions.context // Context is already in Deepgram API format
       }
     };
@@ -1156,6 +1161,7 @@ function DeepgramVoiceInteraction(
       contextMessages: agentOptions.context?.messages || [],
       hasSpeakProvider: 'speak' in settingsMessage.agent,
       speakModel: settingsMessage.agent.speak?.provider?.model,
+      greetingIncluded: 'greeting' in settingsMessage.agent,
       greetingPreview: (settingsMessage.agent.greeting || '').slice(0, 60)
     });
     agentManagerRef.current.sendJSON(settingsMessage);


### PR DESCRIPTION
## Issue
Fixes #234: Duplicate greeting sent on reconnection when context is provided

## Summary
The component was sending a duplicate greeting message on reconnection even when conversation context was provided with existing messages. This occurred because the greeting was always included in the Settings message, regardless of whether context with messages was present.

## Changes
- Modified `sendAgentSettings()` to conditionally include greeting only when:
  - No context is provided (new conversation), OR
  - Context exists but messages array is empty
- When `agentOptions.context.messages` has length > 0, greeting is now omitted to prevent duplicate greeting on reconnection
- Added `greetingIncluded` flag to settings logging for better debugging
- Added test case to `context-preservation-validation.test.js` to verify the fix

## Testing
- ✅ Test case added and passing: "Issue #234: should NOT include greeting in Settings when context with messages is provided"
- ✅ All existing context preservation tests still passing (5/5)

## Behavior
- **Reconnection with context (messages exist)**: Greeting omitted → No duplicate greeting ✅
- **New conversation (no context)**: Greeting included ✅  
- **Empty context array**: Greeting included (treated as new conversation) ✅