### PR TITLE
Fix #246: Ensure MediaStream tracks are always stopped when stopRecording() is called

### DIFF
--- a/src/utils/audio/AudioManager.ts
+++ b/src/utils/audio/AudioManager.ts
@@ -379,8 +379,30 @@ export class AudioManager {
   
   /**
    * Stops recording
+   * 
+   * CRITICAL: Always stops MediaStream tracks to ensure browser recording indicator
+   * disappears, even if isRecording state is false. This fixes issue #246 where
+   * tracks remain active after stop() is called.
    */
   public stopRecording(): void {
+    // CRITICAL FIX for issue #246: Always stop MediaStream tracks if they exist,
+    // regardless of isRecording state. This ensures the browser recording indicator
+    // disappears even if there's a state synchronization issue.
+    if (this.microphoneStream) {
+      this.log('Stopping MediaStream tracks (fix for issue #246)');
+      const tracks = this.microphoneStream.getTracks();
+      tracks.forEach(track => {
+        if (track.readyState !== 'ended') {
+          this.log(`Stopping track: ${track.kind} (${track.label})`);
+          track.stop();
+        } else {
+          this.log(`Track already ended: ${track.kind} (${track.label})`);
+        }
+      });
+      this.microphoneStream = null;
+    }
+    
+    // Early return if not recording (but tracks are already stopped above)
     if (!this.isRecording) {
       return;
     }
@@ -394,17 +416,13 @@ export class AudioManager {
       this.workletNode = null;
     }
     
-    // Stop the microphone
+    // Stop the microphone source node
     if (this.sourceNode) {
       this.sourceNode.disconnect();
       this.sourceNode = null;
     }
     
-    // Stop all microphone tracks
-    if (this.microphoneStream) {
-      this.microphoneStream.getTracks().forEach(track => track.stop());
-      this.microphoneStream = null;
-    }
+    // Note: MediaStream tracks are already stopped above, before the early return check
     
     this.isRecording = false;
     this.emit({ type: 'recording', isRecording: false });


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes issue #246 where the browser recording indicator remains active after calling `stop()` because MediaStream tracks were not being properly stopped.

## 🔍 Root Cause

The `stopRecording()` method in `AudioManager.ts` was returning early if `isRecording` was `false`, which meant MediaStream tracks were never stopped even when they were still active.

## ✅ Solution

- Move MediaStream track stopping **before** the early return check
- Ensures tracks are always stopped if `microphoneStream` exists, regardless of `isRecording` state
- Add detailed logging for track stopping operations
- Check `readyState` before stopping to avoid unnecessary operations

## 🧪 Testing

- MediaStream tracks are now always stopped when `stopRecording()` is called
- Browser recording indicator disappears immediately after `stop()`
- Tracks are stopped even if `isRecording` is `false` due to state synchronization issues

## 📝 Changes

- Modified `src/utils/audio/AudioManager.ts` to stop MediaStream tracks before early return check
- Added comprehensive logging for debugging track stopping

Closes #246