### PR TITLE
Remove window.onConnectionStateChange global - use DOM instead

### DIFF
--- a/test-app/tests/e2e/helpers/test-helpers.js
+++ b/test-app/tests/e2e/helpers/test-helpers.js
@@ -923,7 +923,7 @@ export {
   setupTestPage, // Navigate to test app and wait for page load with configurable timeout
   waitForConnection, // Wait for connection to be established
   waitForSettingsApplied, // Wait for agent settings to be applied (SettingsApplied received from server)
-  setupConnectionStateTracking, // Setup connection state tracking via onConnectionStateChange callback
+  setupConnectionStateTracking, // Setup connection state tracking via DOM elements (data-testid attributes)
   waitForConnectionAndSettings, // Wait for both connection and settings to be applied
   waitForAgentGreeting, // Wait for agent to finish speaking its greeting message
   waitForGreetingIfPresent, // Safely wait for greeting if it plays, otherwise continue (doesn't fail if no greeting)


### PR DESCRIPTION
## Problem

The test-app was using window.testConnectionStates for E2E tests to track connection state changes. This was inconsistent with our refactoring to use DOM-based test data.

## Solution

- Removed all window.testConnectionStates references from lazy-initialization-e2e.spec.js
- Updated tests to use DOM-based connection state tracking via data-testid attributes
- Updated test-helpers.js comment to reflect DOM-based tracking approach
- Fixed test expectation: transcription should be 'connected' after startAudioCapture()
- Removed unnecessary conditional checking for 'not-found' (never exists)

## Benefits

- Consistent with transcript history refactoring (DOM-based instead of window globals)
- More maintainable - tests read from visible DOM elements
- Better debugging - connection states visible in UI
- Cleaner architecture - no test-specific window globals

## Testing

All 7 lazy-initialization E2E tests passing ✅

Fixes #257