### PR TITLE
chore: merge v0.6.2 release to main

### DIFF
--- a/docs/releases/v0.6.2/CHANGELOG.md
+++ b/docs/releases/v0.6.2/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog: v0.6.2
+
+**Component**: `DeepgramVoiceInteraction`  
+**Package**: `@signal-meaning/deepgram-voice-interaction-react`  
+**Release Date**: TBD  
+**Previous Version**: v0.6.1
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 🐛 Fixed
+
+### Agent State Management
+- **Issue #262**: Fixed agent state not transitioning to idle after audio playback stops
+  - Added `AgentStateService.handleAudioPlaybackChange(false)` call when audio playback ends
+  - Ensures proper state synchronization and triggers `onAgentStateChange('idle')` callback
+  - Fixes idle timeout behavior where connections were not closing after 10 seconds of inactivity
+  - Agent state now correctly transitions from `'speaking'` to `'idle'` when TTS audio playback completes
+
+## 📚 Documentation
+
+- **Issue #262**: Added comprehensive investigation summary and test documentation
+  - `ISSUE-262-CUSTOMER-SUMMARY.md`: Complete investigation results and troubleshooting guide
+  - Verified idle timeout mechanism working correctly with real API connections
+  - Added reference tests demonstrating proper idle timeout behavior
+
+## 🔗 Related Issues
+
+- [#262](https://github.com/Signal-Meaning/dg_react_agent/issues/262) - Idle timeout regression: Agent state transition to idle after playback stops
+
+---
+
+**Full Changelog**: [v0.6.1...v0.6.2](https://github.com/Signal-Meaning/dg_react_agent/compare/v0.6.1...v0.6.2)
+

--- a/docs/releases/v0.6.2/PACKAGE-STRUCTURE.md
+++ b/docs/releases/v0.6.2/PACKAGE-STRUCTURE.md
@@ -1,0 +1,121 @@
+# Package Structure: @signal-meaning/deepgram-voice-interaction-react@v0.6.2
+
+## Files Included in Package
+
+As defined in `package.json` "files" field:
+
+```
+signal-meaning-deepgram-voice-interaction-react-v0.6.2/
+├── dist/                      # Built component and utilities
+│   ├── index.js               # CommonJS entry point
+│   ├── index.esm.js           # ES Module entry point
+│   ├── index.d.ts             # TypeScript definitions
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   │       └── index.d.ts
+│   ├── constants/
+│   │   ├── documentation.d.ts
+│   │   └── vad-events.d.ts
+│   ├── hooks/
+│   │   └── useIdleTimeoutManager.d.ts
+│   ├── services/
+│   │   └── AgentStateService.d.ts
+│   ├── test-utils/
+│   │   ├── test-helpers.d.ts
+│   │   └── timeout-testing.d.ts
+│   ├── test-utils.d.ts
+│   ├── types/
+│   │   ├── agent.d.ts
+│   │   ├── connection.d.ts
+│   │   ├── index.d.ts
+│   │   ├── transcription.d.ts
+│   │   └── voiceBot.d.ts
+│   └── utils/
+│       ├── api-key-validator.d.ts
+│       ├── audio/
+│       │   ├── AudioManager.d.ts
+│       │   └── AudioUtils.d.ts
+│       ├── conversation-context.d.ts
+│       ├── IdleTimeoutService.d.ts
+│       ├── instructions-loader.d.ts
+│       ├── plugin-validator.d.ts
+│       ├── state/
+│       │   └── VoiceInteractionState.d.ts
+│       └── websocket/
+│           └── WebSocketManager.d.ts
+├── README.md                  # Package documentation
+├── DEVELOPMENT.md             # Development guide
+├── docs/                      # Documentation
+│   ├── releases/             # Release notes and migration guides
+│   │   └── v0.6.2/
+│   │       ├── CHANGELOG.md
+│   │       ├── MIGRATION.md
+│   │       ├── API-REFERENCE.md
+│   │       ├── RELEASE-NOTES.md
+│   │       ├── INTEGRATION-GUIDE.md
+│   │       ├── AUDIO-BUFFER-MANAGEMENT.md
+│   │       └── PACKAGE-STRUCTURE.md
+│   ├── development/          # Development guides
+│   ├── issues/               # Issue documentation
+│   └── migration/            # Migration guides
+├── scripts/                   # Utility scripts
+│   ├── create-release-issue.sh
+│   ├── check-token-issues.js
+│   ├── validate-plugin.js
+│   ├── generate-test-audio.js
+│   └── [other scripts...]
+└── test-app/                 # Test application demonstrating component usage
+    ├── src/                  # Test app source code
+    │   ├── App.tsx           # Main test app component
+    │   ├── session-management.ts
+    │   └── [other files...]
+    ├── tests/                # E2E tests
+    │   ├── e2e/              # Playwright E2E tests
+    │   ├── unit/             # Unit tests
+    │   └── integration/      # Integration tests
+    ├── docs/                 # Test app documentation
+    └── [other files...]
+```
+
+## Package Entry Points
+
+From `package.json`:
+- **Main (CommonJS)**: `dist/index.js`
+- **Module (ESM)**: `dist/index.esm.js`
+- **Types**: `dist/index.d.ts`
+
+## Purpose of Each Directory
+
+- **`dist/`**: Built production code and TypeScript definitions
+- **`README.md`**: Package overview and quick start
+- **`DEVELOPMENT.md`**: Development setup and contribution guide
+- **`docs/`**: Comprehensive documentation (releases, guides, issues)
+- **`scripts/`**: Utility scripts for development and publishing
+- **`test-app/`**: Reference implementation and E2E test suite
+
+## Package Size Information
+
+<!-- Update with actual sizes when available -->
+- **Total Package Size**: [TBD]
+- **dist/**: [TBD]
+- **docs/**: [TBD]
+- **test-app/**: [TBD]
+
+## Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@0.6.2
+```
+
+## Verification
+
+After installation, verify the package structure:
+
+```bash
+# Check installed files
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/
+
+# Verify entry points exist
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/dist/
+```
+

--- a/docs/releases/v0.6.2/RELEASE-NOTES.md
+++ b/docs/releases/v0.6.2/RELEASE-NOTES.md
@@ -1,0 +1,41 @@
+## 🚀 Release v0.6.2: Patch Release
+
+**Version**: v0.6.2  
+**Date**: TBD  
+**Status**: In Progress  
+**Previous Version**: v0.6.1
+
+### Overview
+
+This is a patch release for version v0.6.2 of the Deepgram Voice Interaction React component. This release includes a critical bug fix for agent state management with no breaking changes.
+
+### 🐛 Key Fixes
+
+- **Issue #262**: Fixed agent state not transitioning to idle after audio playback stops
+  - Agent state now correctly transitions from `'speaking'` to `'idle'` when TTS audio playback completes
+  - Ensures proper state synchronization and triggers `onAgentStateChange('idle')` callback
+  - Fixes idle timeout behavior where connections were not closing after 10 seconds of inactivity
+
+### 📦 Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@0.6.2 --registry https://npm.pkg.github.com
+```
+
+### 📚 Documentation
+
+- [Changelog](docs/releases/v0.6.2/CHANGELOG.md)
+- [Package Structure](docs/releases/v0.6.2/PACKAGE-STRUCTURE.md)
+
+### 🔗 Related Issues
+
+- [#262](https://github.com/Signal-Meaning/dg_react_agent/issues/262) - Idle timeout regression: Agent state transition to idle after playback stops
+
+### 📋 Migration Notes
+
+This is a **patch release** with **no breaking changes**. All existing APIs remain unchanged and fully compatible.
+
+---
+
+**Full Changelog**: [v0.6.1...v0.6.2](https://github.com/Signal-Meaning/dg_react_agent/compare/v0.6.1...v0.6.2)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A React component for real-time transcription and voice agent interactions using Deepgram APIs",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -36,7 +36,7 @@
     },
     "..": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"


### PR DESCRIPTION
Merging v0.6.2 release commit to main branch.

## Release Summary
- **Version**: v0.6.2
- **Type**: Patch release
- **Issue**: #262 - Fixed agent state transition to idle after playback stops

## Changes
- Fixed agent state not transitioning to idle after audio playback stops
- Added AgentStateService.handleAudioPlaybackChange() call when audio playback ends
- Ensures proper state synchronization and triggers onAgentStateChange('idle') callback
- Fixes idle timeout behavior where connections were not closing after 10 seconds

## Status
- ✅ Package published to GitHub Registry
- ✅ GitHub release created
- ✅ All tests passing
- ✅ Documentation complete

Related: #265