### PR TITLE
Fix Issue #262: Remove ConversationText from idle timeout reset logic

### DIFF
--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -1394,6 +1394,12 @@ function DeepgramVoiceInteraction(
           metadata: data,
         };
         
+        // Note: ConversationText messages are redundant for idle timeout management.
+        // User text activity should be handled via:
+        // 1. injectUserMessage() - triggers InjectUserMessage which resets timeout
+        // 2. onUserMessage callback - application can call handleMeaningfulActivity if needed
+        // We don't reset timeout here because ConversationText is a transcript, not an activity indicator.
+        
         onUserMessage?.(response);
         return;
       }


### PR DESCRIPTION
## Summary

Fixes Issue #262/#430: Idle timeout not firing due to ConversationText messages resetting the timeout.

## Problem

Assistant ConversationText messages were resetting the idle timeout even when agent/user were idle, preventing the timeout from ever completing. This caused connections to stay open until Deepgram's websocket timeout (~60 seconds) instead of closing after the configured idle timeout (10 seconds).

## Solution

Removed ConversationText messages (both user and assistant) from idle timeout reset logic in `WebSocketManager.isMeaningfulUserActivity()` because:

- **ConversationText messages are redundant**: They are transcripts, not activity indicators
- **User text activity**: Already handled via `injectUserMessage()` → `InjectUserMessage` message
- **Agent activity**: Already tracked via `AgentThinking`, `AgentStartedSpeaking`, `AgentAudioDone` messages and state changes

## Changes

1. **`src/utils/websocket/WebSocketManager.ts`**
   - Removed ConversationText handling from `isMeaningfulUserActivity()`
   - Added documentation explaining ConversationText redundancy

2. **`src/components/DeepgramVoiceInteraction/index.tsx`**
   - Added comment explaining ConversationText redundancy and proper handling

3. **`tests/agent-state-handling.test.ts`**
   - Updated test documentation to reflect ConversationText removal

4. **`docs/issues/ISSUE-262/ISSUE-262-INTERNAL-RECORD.md`**
   - Added follow-up fix documentation

## Testing

All tests passing:
- ✅ 6 unit tests for Issue #262/#430 (all passing)
- ✅ E2E tests verify timeout completes correctly

## Related Issues

- Issue #262: Original report
- Issue #430 (voice-commerce): Customer report with detailed diagnostics

Closes #262