### PR TITLE
chore: prepare release v0.6.4

### DIFF
--- a/docs/releases/v0.6.4/CHANGELOG.md
+++ b/docs/releases/v0.6.4/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog: v0.6.4
+
+**Component**: `DeepgramVoiceInteraction`  
+**Package**: `@signal-meaning/deepgram-voice-interaction-react`  
+**Release Date**: November 8, 2025  
+**Previous Version**: v0.6.3
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 🐛 Fixed
+
+### Idle Timeout Management
+- **Issue #262/#430**: Fixed idle timeout not firing due to `ConversationText` messages resetting the timeout
+  - **Root Cause**: Assistant `ConversationText` messages were resetting the idle timeout even when agent/user were idle, preventing the timeout from ever completing
+  - **Fix**: Removed `ConversationText` messages (both user and assistant) from idle timeout reset logic because:
+    - `ConversationText` messages are transcripts, not activity indicators
+    - User text activity is already handled via `injectUserMessage()` → `InjectUserMessage` message
+    - Agent activity is already tracked via `AgentThinking`, `AgentStartedSpeaking`, `AgentAudioDone` messages and state changes
+  - **Impact**: Idle timeout now works correctly even when `ConversationText` messages arrive, as they no longer interfere with timeout management
+  - Connections will now close after configured idle timeout (e.g., 10 seconds) instead of staying open until websocket timeout (~60 seconds)
+
+## 📚 Documentation
+
+- **Issue #262**: Added follow-up fix documentation explaining `ConversationText` redundancy
+  - Updated `WebSocketManager.ts` with inline documentation explaining why `ConversationText` messages don't reset timeout
+  - Updated component documentation clarifying user text activity handling
+  - Updated test documentation in `agent-state-handling.test.ts`
+
+## 🔗 Related Issues
+
+- [#262](https://github.com/Signal-Meaning/dg_react_agent/issues/262) - Idle timeout not restarting after USER_STOPPED_SPEAKING
+- [#430 (voice-commerce)](https://github.com/Signal-Meaning/voice-commerce/issues/430) - Idle timeout not firing, connections staying open until websocket timeout
+
+---
+
+**Full Changelog**: [v0.6.3...v0.6.4](https://github.com/Signal-Meaning/dg_react_agent/compare/v0.6.3...v0.6.4)
+

--- a/docs/releases/v0.6.4/PACKAGE-STRUCTURE.md
+++ b/docs/releases/v0.6.4/PACKAGE-STRUCTURE.md
@@ -1,0 +1,115 @@
+# Package Structure: @signal-meaning/deepgram-voice-interaction-react@v0.6.4
+
+## Files Included in Package
+
+As defined in `package.json` "files" field:
+
+```
+signal-meaning-deepgram-voice-interaction-react-v0.6.4/
+├── dist/                      # Built component and utilities
+│   ├── index.js               # CommonJS entry point
+│   ├── index.esm.js           # ES Module entry point
+│   ├── index.d.ts             # TypeScript definitions
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   │       └── index.d.ts
+│   ├── constants/
+│   │   ├── documentation.d.ts
+│   │   └── vad-events.d.ts
+│   ├── hooks/
+│   │   └── useIdleTimeoutManager.d.ts
+│   ├── services/
+│   │   └── AgentStateService.d.ts
+│   ├── test-utils/
+│   │   ├── test-helpers.d.ts
+│   │   └── timeout-testing.d.ts
+│   ├── test-utils.d.ts
+│   ├── types/
+│   │   ├── agent.d.ts
+│   │   ├── connection.d.ts
+│   │   ├── index.d.ts
+│   │   ├── transcription.d.ts
+│   │   └── voiceBot.d.ts
+│   └── utils/
+│       ├── api-key-validator.d.ts
+│       ├── audio/
+│       │   ├── AudioManager.d.ts
+│       │   └── AudioUtils.d.ts
+│       ├── conversation-context.d.ts
+│       ├── IdleTimeoutService.d.ts
+│       ├── instructions-loader.d.ts
+│       ├── plugin-validator.d.ts
+│       ├── state/
+│       │   └── VoiceInteractionState.d.ts
+│       └── websocket/
+│           └── WebSocketManager.d.ts
+├── README.md                  # Package documentation
+├── DEVELOPMENT.md             # Development guide
+├── docs/                      # Documentation
+│   ├── releases/             # Release notes and migration guides
+│   │   └── v0.6.4/
+│   │       ├── CHANGELOG.md
+│   │       ├── RELEASE-NOTES.md
+│   │       └── PACKAGE-STRUCTURE.md
+│   ├── development/          # Development guides
+│   ├── issues/               # Issue documentation
+│   └── migration/            # Migration guides
+├── scripts/                   # Utility scripts
+│   ├── create-release-issue.sh
+│   ├── check-token-issues.js
+│   ├── validate-plugin.js
+│   ├── generate-test-audio.js
+│   └── [other scripts...]
+└── test-app/                 # Test application demonstrating component usage
+    ├── src/                  # Test app source code
+    │   ├── App.tsx           # Main test app component
+    │   ├── session-management.ts
+    │   └── [other files...]
+    ├── tests/                # E2E tests
+    │   ├── e2e/              # Playwright E2E tests
+    │   ├── unit/             # Unit tests
+    │   └── integration/      # Integration tests
+    ├── docs/                 # Test app documentation
+    └── [other files...]
+```
+
+## Package Entry Points
+
+From `package.json`:
+- **Main (CommonJS)**: `dist/index.js`
+- **Module (ESM)**: `dist/index.esm.js`
+- **Types**: `dist/index.d.ts`
+
+## Purpose of Each Directory
+
+- **`dist/`**: Built production code and TypeScript definitions
+- **`README.md`**: Package overview and quick start
+- **`DEVELOPMENT.md`**: Development setup and contribution guide
+- **`docs/`**: Comprehensive documentation (releases, guides, issues)
+- **`scripts/`**: Utility scripts for development and publishing
+- **`test-app/`**: Reference implementation and E2E test suite
+
+## Package Size Information
+
+- **Total Package Size**: 1.7 MB (tarball)
+- **Unpacked Size**: 5.9 MB
+- **Total Files**: 279
+
+## Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@0.6.4
+```
+
+## Verification
+
+After installation, verify the package structure:
+
+```bash
+# Check installed files
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/
+
+# Verify entry points exist
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/dist/
+```
+

--- a/docs/releases/v0.6.4/RELEASE-NOTES.md
+++ b/docs/releases/v0.6.4/RELEASE-NOTES.md
@@ -1,0 +1,54 @@
+## 🚀 Release v0.6.4: Patch Release
+
+**Version**: v0.6.4  
+**Date**: November 8, 2025  
+**Status**: Released  
+**Previous Version**: v0.6.3
+
+### Overview
+
+This is a patch release for version v0.6.4 of the Deepgram Voice Interaction React component. This release includes a critical bug fix for idle timeout management with no breaking changes.
+
+### 🐛 Key Fixes
+
+- **Issue #262/#430**: Fixed idle timeout not firing due to `ConversationText` messages resetting the timeout
+  - **Root Cause**: Assistant `ConversationText` messages were resetting the idle timeout even when agent/user were idle, preventing the timeout from ever completing
+  - **Fix**: Removed `ConversationText` messages (both user and assistant) from idle timeout reset logic
+  - **Rationale**: 
+    - `ConversationText` messages are transcripts, not activity indicators
+    - User text activity is already handled via `injectUserMessage()` → `InjectUserMessage` message
+    - Agent activity is already tracked via `AgentThinking`, `AgentStartedSpeaking`, `AgentAudioDone` messages and state changes
+  - **Impact**: Idle timeout now works correctly even when `ConversationText` messages arrive
+  - Connections will now close after configured idle timeout (e.g., 10 seconds) instead of staying open until websocket timeout (~60 seconds)
+
+### 📦 Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@0.6.4 --registry https://npm.pkg.github.com
+```
+
+### 📚 Documentation
+
+- [Changelog](docs/releases/v0.6.4/CHANGELOG.md)
+- [Package Structure](docs/releases/v0.6.4/PACKAGE-STRUCTURE.md)
+
+### 🔗 Related Issues
+
+- [#262](https://github.com/Signal-Meaning/dg_react_agent/issues/262) - Idle timeout not restarting after USER_STOPPED_SPEAKING
+- [#430 (voice-commerce)](https://github.com/Signal-Meaning/voice-commerce/issues/430) - Idle timeout not firing, connections staying open until websocket timeout
+
+### 📋 Migration Notes
+
+This is a **patch release** with **no breaking changes**. All existing APIs remain unchanged and fully compatible.
+
+### 🧪 Testing
+
+- ✅ All unit tests passing (485 passed, 6 skipped)
+- ✅ All E2E tests passing
+- ✅ No linting errors
+- ✅ Build successful
+
+---
+
+**Full Changelog**: [v0.6.3...v0.6.4](https://github.com/Signal-Meaning/dg_react_agent/compare/v0.6.3...v0.6.4)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A React component for real-time transcription and voice agent interactions using Deepgram APIs",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -36,7 +36,7 @@
     },
     "..": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"


### PR DESCRIPTION
Release v0.6.4: Fix idle timeout not firing due to ConversationText messages

## Changes
- Bump version to v0.6.4
- Add release documentation (CHANGELOG.md, RELEASE-NOTES.md, PACKAGE-STRUCTURE.md)
- Tag v0.6.4 created and pushed
- GitHub release created
- Package published to GitHub Package Registry

## Related Issues
- Fixes #262 - Idle timeout not restarting after USER_STOPPED_SPEAKING
- Fixes #430 (voice-commerce) - Idle timeout not firing

## Release Status
✅ All tests passing (485 passed, 6 skipped)
✅ Package published successfully
✅ Release documentation complete