### PR TITLE
fix(release): build in CI only; remove required local build/package (fixes #382)

### DIFF
--- a/.github/ISSUE_TEMPLATE/README.md
+++ b/.github/ISSUE_TEMPLATE/README.md
@@ -11,7 +11,7 @@ This directory contains GitHub issue templates for the Deepgram Voice Interactio
 - Complete release process checklist
 - Pre-release preparation steps
 - Version management
-- Build and package validation
+- CI build and package validation (no local build required)
 - Comprehensive documentation requirements
 - Git operations and tagging
 - Package publishing to GitHub Registry

--- a/.github/ISSUE_TEMPLATE/quick-release.md
+++ b/.github/ISSUE_TEMPLATE/quick-release.md
@@ -28,13 +28,11 @@ This is a patch release for version vX.X.X of the Deepgram Voice Interaction Rea
 - [ ] **Linting Clean**: No linting errors
   - [ ] Run: `npm run lint`
 
-#### Version & Build
+#### Version & Build (CI performs build — no local build required)
 - [ ] **Bump Version**: Update to vX.X.X
   - [ ] Run: `npm version patch`
-- [ ] **Build Package**: Create production build
-  - [ ] Run: `npm run build`
-- [ ] **Test Package**: Verify package works
-  - [ ] Run: `npm run package:local`
+- [ ] **Do not run build/package locally for release.** CI builds and validates when you create the GitHub release (see Publish below).
+- [ ] **Optional**: Run `npm run build` or `npm run package:local` locally to verify; do **not** commit any `.tgz` (gitignored).
 
 #### Documentation
 - [ ] **⚠️ CRITICAL: Create Release Documentation BEFORE Publishing** ⚠️
@@ -57,7 +55,7 @@ This is a patch release for version vX.X.X of the Deepgram Voice Interaction Rea
 - [ ] **Publish**: Publish to GitHub Registry
   - [ ] **⚠️ Documentation must be committed to release branch BEFORE creating GitHub release** ⚠️
   - [ ] **Preferred**: Use CI build (create GitHub release to trigger `.github/workflows/test-and-publish.yml`)
-    - Create GitHub release (this triggers CI publish workflow)
+    - Create GitHub release (this triggers CI; CI builds from source and publishes)
     - **Monitor CI workflow**: Wait for CI build to complete successfully
       - Check GitHub Actions workflow status
       - Verify all CI checks pass

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -39,16 +39,10 @@ This issue tracks the complete release process for version vX.X.X of the Deepgra
   - [ ] Run: `npm update`
   - [ ] Review and update any outdated dependencies
 
-#### Build and Package
-- [ ] **Clean Build**: Clean previous builds
-  - [ ] Run: `npm run clean`
-- [ ] **Build Package**: Create production build
-  - [ ] Run: `npm run build`
-- [ ] **Validate Package**: Ensure package is valid
-  - [ ] Run: `npm run validate`
-- [ ] **Test Package**: Test package installation
-  - [ ] Run: `npm run package:local`
-  - [ ] Verify package can be installed and imported
+#### Build and Package (CI performs build — no local build required)
+- [ ] **Do not run build/package locally for release.** CI builds and validates when you create the GitHub release (see Package Publishing below).
+- [ ] **Optional local validation only**: If you want to verify build locally before pushing:
+  - [ ] Run: `npm run clean` then `npm run build` then `npm run validate` (or `npm run package:local`). Do **not** commit any `.tgz` or `dist/` — they are gitignored; CI will build from source.
 
 #### Documentation
 - [ ] **Create Release Documentation**: Follow the established structure
@@ -87,7 +81,7 @@ This issue tracks the complete release process for version vX.X.X of the Deepgra
 - [ ] **Publish to GitHub Registry**: Publish package to GitHub Package Registry
   - [ ] **Preferred**: Use CI build (validated CI build)
     - Create GitHub release to trigger `.github/workflows/test-and-publish.yml`
-    - CI workflow will: test (mock APIs only), build, validate, and publish
+    - CI workflow will: test (mock APIs only), **build in CI**, validate package, and publish. No local build required.
     - Test job runs first: linting, mock tests, build, package validation
     - Publish job only runs if test job succeeds
     - **All non-skipped tests must pass** before publishing
@@ -125,9 +119,8 @@ This issue tracks the complete release process for version vX.X.X of the Deepgra
 - [ ] **Update Main Branch**: Merge release branch to main
   - [ ] Merge: `release/vX.X.X` → `main`
   - [ ] Push: `git push origin main`
-- [ ] **Clean Up**: Clean up release artifacts
-  - [ ] Remove: Local `.tgz` files
-  - [ ] Remove: Build artifacts if needed
+- [ ] **Clean Up**: Clean up release artifacts (only if you ran optional local package)
+  - [ ] If you ran `npm run package:local` locally: remove any `.tgz` in repo root, or leave (they are gitignored)
 - [ ] **Announcement**: Announce release (if applicable)
   - [ ] Update: Any external documentation
   - [ ] Notify: Relevant teams or users
@@ -142,14 +135,14 @@ The following GitHub Actions workflows will be triggered automatically:
    - Tests package installation from tarball
 
 2. **Test and Publish Workflow** (`.github/workflows/test-and-publish.yml`):
-   - Runs on GitHub release creation
+   - Runs on GitHub release creation (or workflow_dispatch)
    - **Test Job**: Runs first and includes:
      - Linting (`npm run lint`)
      - Tests with mock APIs only (`npm run test:mock` - no real API calls)
-     - Build (`npm run build`)
+     - **Build in CI** (`npm run build`)
      - Package validation (`npm run package:local`)
    - **Publish Job**: Only runs if test job succeeds
-     - Publishes to GitHub Package Registry
+     - **Builds again in CI** and publishes to GitHub Package Registry
    - Verifies package installation
    - **All non-skipped tests must pass** before publishing
 

--- a/docs/issues/ISSUE-381/release-v0.7.11-body.md
+++ b/docs/issues/ISSUE-381/release-v0.7.11-body.md
@@ -21,13 +21,11 @@ This is a patch release for version v0.7.11 of the Deepgram Voice Interaction Re
 - [ ] **Linting Clean**: No linting errors
   - [ ] Run: `npm run lint`
 
-#### Version & Build
+#### Version & Build (CI performs build — no local build required)
 - [ ] **Bump Version**: Update to v0.7.11
   - [ ] Run: `npm version patch`
-- [ ] **Build Package**: Create production build
-  - [ ] Run: `npm run build`
-- [ ] **Test Package**: Verify package works
-  - [ ] Run: `npm run package:local`
+- [ ] **Do not run build/package locally for release.** CI builds and validates when you create the GitHub release (see Publish below).
+- [ ] **Optional**: Run `npm run build` or `npm run package:local` locally to verify; do **not** commit any `.tgz` (gitignored).
 
 #### Documentation
 - [ ] **⚠️ CRITICAL: Create Release Documentation BEFORE Publishing** ⚠️
@@ -50,7 +48,7 @@ This is a patch release for version v0.7.11 of the Deepgram Voice Interaction Re
 - [ ] **Publish**: Publish to GitHub Registry
   - [ ] **⚠️ Documentation must be committed to release branch BEFORE creating GitHub release** ⚠️
   - [ ] **Preferred**: Use CI build (create GitHub release to trigger `.github/workflows/test-and-publish.yml`)
-    - Create GitHub release (this triggers CI publish workflow)
+    - Create GitHub release (this triggers CI; CI builds from source and publishes)
     - **Monitor CI workflow**: Wait for CI build to complete successfully
       - Check GitHub Actions workflow status
       - Verify all CI checks pass

--- a/docs/issues/ISSUE-382/README.md
+++ b/docs/issues/ISSUE-382/README.md
@@ -1,0 +1,144 @@
+# Issue #382: Investigate Zipped Release Packages in Git Repo
+
+**GitHub Issue**: [#382](https://github.com/Signal-Meaning/dg_react_agent/issues/382)  
+**State**: OPEN  
+**Author**: davidrmcgee  
+**Branch**: `davidrmcgee/issue382`  
+**Created**: 2026-02-01
+
+---
+
+## Objective
+
+Identify why zipped packages of releases are present in the Git repository.
+
+## Context
+
+The repository appears to contain zipped release packages within the Git history or current state. This is unexpected for a source code repository.
+
+## Investigation goals
+
+- Determine the **origin** of these zipped packages (e.g. accidental commits, CI artifacts, release scripts).
+- Clarify their **purpose** (intended vs unintended).
+- Decide whether they should be **removed** or **excluded** from version control (e.g. via `.gitignore`, `.gitattributes`, or history cleanup).
+- Document findings and any recommended changes to avoid recurrence.
+
+---
+
+## Suspected cause (pre-RCA)
+
+**Hypothesis**: The release process performs a local build, and that local build (or its artifacts) is what is introducing zipped release packages into the repo. Fixing the release process to avoid committing or including those build artifacts is the expected remedy.
+
+*RCA below confirms or refutes this theory.*
+
+---
+
+## Root cause analysis (RCA)
+
+### Verdict: **Theory confirmed**
+
+The release process **does** perform a local build and local packaging. That process is the source of release-package artifacts that ended up in the repo. Your suspicion is correct.
+
+### Evidence
+
+1. **Release process requires local build and package**
+   - `.github/ISSUE_TEMPLATE/release-checklist.md` and `quick-release.md` both instruct: run `npm run build` and `npm run package:local` as part of "Build Package" and "Test Package".
+   - `scripts/package-for-local.sh` runs `npm run build` then `npm pack`, producing a **`.tgz`** file in the repo root (e.g. `deepgram-voice-interaction-react-0.1.0.tgz`).
+   - In non-interactive mode (e.g. CI) the script **keeps** the `.tgz`; in interactive mode it prompts "Do you want to clean up the .tgz file? (y/N)" and defaults to keeping it.
+
+2. **Artifacts in Git history are .tgz (not .zip)**
+   - `git log --all -- "*.tgz"` shows committed `.tgz` files: `deepgram-voice-interaction-react-0.1.0.tgz`, `deepgram-react-0.1.0.tgz` in commits such as "create new tgz, update readme", "add mode capability", and "Fixed problems with running npm run build...".
+   - No `.zip` files appear in `git ls-files` or `git log`; no script in the repo creates `.zip`. "Zipped" in the issue is interpreted as **packaged release artifacts** (here: `.tgz` tarballs).
+
+3. **Mitigation already in place**
+   - `.gitignore` contains `*.tgz` (added in commits like "Add .tgz files to .gitignore to ignore build artifacts"), so new `.tgz` files are no longer tracked.
+   - Commits "Remove old 0.1.0.tgz file from tracking, new 0.1.1.tgz is ignored" removed the then-tracked tarball from the index.
+
+4. **CI does not commit**
+   - `.github/workflows/test-and-publish.yml` runs `npm run build` and `npm run package:local` in CI but does not commit; artifacts stay in the runner. So the **only** way package files entered the repo was **local** runs of the release steps followed by commit.
+
+### Conclusion
+
+- **Origin**: Local execution of the documented release steps (`npm run build`, `npm run package:local`), which leave a `.tgz` in the repo root, followed by commit before (or without) cleanup.
+- **Purpose**: Unintended. The tarballs were build/test artifacts that were committed by mistake.
+- **Fix**: The process that needed fixing was "local build + package leaving artifact in tree and it getting committed." That is addressed by ignoring `*.tgz`. Optional hardening: add `*.zip` to `.gitignore`, and make the release checklist explicitly say "do not commit the .tgz produced by package:local; remove or leave it ignored."
+
+---
+
+## Release process fix: build in CI, not locally
+
+### Is the build stage missing in CI?
+
+**No.** The CI workflow (`.github/workflows/test-and-publish.yml`) already performs the build in CI:
+
+- **test-jest** job (runs on push to main, release published, workflow_dispatch): runs `npm run build`, then `npm run package:local`, then tests package installation from the tarball. So CI builds and validates the package.
+- **publish** job (runs only on `release: published` or `workflow_dispatch`, after test-jest): runs `npm run build` again, then `npm publish`. So the package that gets published is built in CI from the committed source.
+
+When you create a GitHub release (or run the workflow manually), CI runs test-jest (build + package + tests) and, if that succeeds, publish (build + publish). The canonical build for release is therefore in CI.
+
+### Why are builds still being staged locally?
+
+Because the **release checklist and quick-release template** instruct maintainers to run the build and package **locally** as required steps before committing and creating the release:
+
+- **release-checklist.md** — "Build and Package" section: "Clean Build" (`npm run clean`), "Build Package" (`npm run build`), "Validate Package" (`npm run validate`), "Test Package" (`npm run package:local`). Those are listed as checklist items before "Commit Changes" and "Create Release Branch".
+- **quick-release.md** — "Version & Build" section: "Build Package" (`npm run build`), "Test Package" (`npm run package:local`) before "Documentation" and "Release".
+
+So the reason builds are still being run locally is **documentation-driven**: the checklists were written to have people **validate** the build and package on their machine before pushing and triggering CI. That made local build/package feel required, which (1) leaves `.tgz` in the tree, (2) implies the "real" build might be local, and (3) can lead to accidentally committing artifacts. In reality, CI already does the full build and publish when you create the GitHub release — the local build/package steps are **redundant** for the purpose of publishing.
+
+### Fix applied
+
+- **Release checklist** and **quick-release** are updated so that **local build and package are not required**. The checklists now state that **CI builds and validates** when you create the GitHub release; maintainers only need to run tests and lint locally (e.g. `npm test`, `npm run lint`) before pushing. Optional: you may run `npm run build` or `npm run package:local` locally for quick validation, but do **not** commit any `.tgz` (they are gitignored).
+
+---
+
+## Progress and findings
+
+### Current state
+
+- **Status**: RCA complete; theory confirmed.
+- **Findings**: Local release process (build + `package:local`) produced `.tgz` artifacts that were committed before `*.tgz` was added to `.gitignore`. No `.zip` in repo or scripts; "zipped" = packaged release artifacts.
+- **Artifacts in repo**: Historical only. Commits touching `.tgz`: e.g. `deepgram-voice-interaction-react-0.1.0.tgz`, `deepgram-react-0.1.0.tgz` (see `git log --all -- "*.tgz"`). Current tree: none tracked (ignored by `.gitignore`).
+
+### Origin
+
+- Local run of release checklist: `npm run build` and `npm run package:local` (which runs `scripts/package-for-local.sh` and `npm pack`). The resulting `.tgz` was left in the repo root and committed.
+
+### Purpose
+
+- Unintended. The packages were build/test artifacts from validating the release; they were not meant to be versioned.
+
+### Recommendation
+
+- **Already done**: `*.tgz` in `.gitignore` prevents new tarballs from being tracked.
+- **Optional**: Add `*.zip` to `.gitignore` for consistency. In release checklist / quick-release, add an explicit step: "Do not commit the .tgz produced by package:local; delete it or rely on .gitignore."
+- **History**: No obligation to rewrite history; current state is clean. If desired, document in release docs that package artifacts must not be committed.
+
+---
+
+## Resolution checklist
+
+Use this checklist to confirm the issue is resolved before closing.
+
+- [x] **Origin identified** — Local release process: `npm run build` and `npm run package:local` produced `.tgz` in repo root; files were committed before `*.tgz` was in `.gitignore`.
+- [x] **Purpose clarified** — Unintended; build/test artifacts from release validation, not meant to be versioned.
+- [x] **Decision made** — Ignore package artifacts via `.gitignore` (already done for `*.tgz`). Optional: add `*.zip`; document "do not commit" in release checklist.
+- [x] **Actions taken** — Release checklist and quick-release updated so local build/package are not required; CI builds from source when GitHub release is created.
+- [x] **Recurrence prevented** — Checklists now state CI performs the build; local build/package optional only; `.gitignore` already prevents committing `.tgz`.
+- [x] **Findings documented** — This README updated with RCA and conclusion.
+
+---
+
+## Related
+
+- **`.gitignore`** — Currently ignores `*.tgz`; no `*.zip` pattern (as of 2026-02-01). See repo root `.gitignore`.
+- **Release workflow** — See `.github/workflows/` and `scripts/` for release and packaging scripts that might produce zips.
+
+---
+
+## Document history
+
+| Date       | Change |
+|------------|--------|
+| 2026-02-01 | Initial tracking document created from gh issue view 382; branch `davidrmcgee/issue382` created. |
+| 2026-02-01 | Added suspected cause (local release build). RCA completed: theory **confirmed** — local `npm run build` + `package:local` produced `.tgz` that was committed before `*.tgz` in `.gitignore`; no `.zip` in repo. Optional recommendations: add `*.zip` to `.gitignore`, document "do not commit" in release checklist. |
+| 2026-02-01 | Release process fix: documented that CI build stage is **not** missing (test-and-publish.yml builds in test-jest and publish jobs). Explained why builds were still staged locally: release-checklist and quick-release **required** local build/package. Updated both templates so local build/package are **not required**; CI builds from source when GitHub release is created. |

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -133,7 +133,7 @@ npm run release:issue 1.0.0 major
 #### Release Checklist Template (Minor/Major)
 - Complete pre-release preparation
 - Version management and dependency updates
-- Build and package validation
+- CI build and package validation (no local build required)
 - Comprehensive documentation requirements
 - Git operations and tagging
 - Package publishing to GitHub Registry
@@ -170,7 +170,7 @@ Each release includes a comprehensive checklist to ensure all steps are complete
 3. **Follow the Process**: Work through each section systematically:
    - **Pre-Release Preparation**: Code review, testing, linting
    - **Version Management**: Bump version, update dependencies
-   - **Build and Package**: Clean, build, validate, test package
+   - **Build and Package**: CI builds and validates when you create the GitHub release (no local build required)
    - **Documentation**: Create all required documentation files
    - **Git Operations**: Commit, branch, tag
    - **Package Publishing**: Publish to GitHub Registry


### PR DESCRIPTION
## Summary
- **Issue**: #382 — Investigate zipped release packages in git repo
- **Root cause**: Release checklists required local `npm run build` and `npm run package:local`, which left `.tgz` in repo and led to accidental commits (historical; `.gitignore` now has `*.tgz`).
- **Fix**: Release process now documents that **CI performs the build** when you create the GitHub release; local build/package are **not required** (optional validation only).

## Changes
- **docs/issues/ISSUE-382/README.md**: RCA, theory confirmed, release process fix explanation
- **release-checklist.md** & **quick-release.md**: Build and package steps are "CI performs build — no local build required"; no required local build/`package:local`
- **.github/ISSUE_TEMPLATE/README.md**, **docs/releases/README.md**: CI build and package validation (no local build required)
- **Post-release cleanup**: Only if optional local package was run
- **docs/issues/ISSUE-381/release-v0.7.11-body.md**: Aligned with new process

Closes #382

Made with [Cursor](https://cursor.com)