### PR TITLE
Merge release/v0.7.11 into main

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -116,9 +116,11 @@ This issue tracks the complete release process for version vX.X.X of the Deepgra
   - [ ] Add: `vX.X.X` label to `release/vX.X.X` branch
 
 #### Post-Release
-- [ ] **Update Main Branch**: Merge release branch to main
-  - [ ] Merge: `release/vX.X.X` → `main`
-  - [ ] Push: `git push origin main`
+- [ ] **Update Main Branch**: Merge release branch to main **via Pull Request** (required — do not push directly to `main`)
+  - [ ] Open a PR: `release/vX.X.X` → `main` (e.g. "Merge release/vX.X.X into main")
+  - [ ] Get review/approval if branch protection requires it
+  - [ ] Merge the PR (squash or merge commit per repo policy)
+  - [ ] **Do not** `git push origin main` from a local merge — use the GitHub PR merge so branch protection is satisfied
 - [ ] **Clean Up**: Clean up release artifacts (only if you ran optional local package)
   - [ ] If you ran `npm run package:local` locally: remove any `.tgz` in repo root, or leave (they are gitignored)
 - [ ] **Announcement**: Announce release (if applicable)
@@ -179,6 +181,7 @@ Follow the established documentation structure in `docs/releases/`:
 3. **Testing**: All tests must pass before release
 4. **Documentation**: Comprehensive documentation is required
 5. **Breaking Changes**: Must be clearly documented in MIGRATION.md
+6. **Merge to main via PR**: Branch protection may require changes through a pull request. Do **not** push a local merge directly to `main`; open a PR from `release/vX.X.X` to `main` and merge the PR.
 
 ### 🔗 Related Documentation
 

--- a/docs/releases/v0.4.0/RELEASE-CHECKLIST.md
+++ b/docs/releases/v0.4.0/RELEASE-CHECKLIST.md
@@ -8,96 +8,96 @@ This document tracks the complete release process for version 0.4.0 of the Deepg
 ### 📋 Release Checklist
 
 #### Pre-Release Preparation
-- [ ] **Code Review Complete**: All PRs merged and code reviewed
-- [ ] **Tests Passing**: All unit tests and E2E tests passing
-  - [ ] Run: `npm test`
-  - [ ] Run: `npm run test:e2e`
-- [ ] **Linting Clean**: No linting errors
-  - [ ] Run: `npm run lint`
-- [ ] **Documentation Updated**: All relevant documentation updated
-- [ ] **Breaking Changes Documented**: Any breaking changes identified and documented
+- [x] **Code Review Complete**: All PRs merged and code reviewed
+- [x] **Tests Passing**: All unit tests and E2E tests passing
+  - [x] Run: `npm test`
+  - [x] Run: `npm run test:e2e`
+- [x] **Linting Clean**: No linting errors
+  - [x] Run: `npm run lint`
+- [x] **Documentation Updated**: All relevant documentation updated
+- [x] **Breaking Changes Documented**: Any breaking changes identified and documented
 
 #### Version Management
-- [ ] **Bump Version**: Update package.json to 0.4.0
-  - [ ] Run: `npm version minor` (or manually update to 0.4.0)
-- [ ] **Update Dependencies**: Ensure all dependencies are up to date
-  - [ ] Run: `npm update`
-  - [ ] Review and update any outdated dependencies
+- [x] **Bump Version**: Update package.json to 0.4.0
+  - [x] Run: `npm version minor` (or manually update to 0.4.0)
+- [x] **Update Dependencies**: Ensure all dependencies are up to date
+  - [x] Run: `npm update`
+  - [x] Review and update any outdated dependencies
 
 #### Build and Package
-- [ ] **Clean Build**: Clean previous builds
-  - [ ] Run: `npm run clean`
-- [ ] **Build Package**: Create production build
-  - [ ] Run: `npm run build`
-- [ ] **Validate Package**: Ensure package is valid
-  - [ ] Run: `npm run validate`
-- [ ] **Test Package**: Test package installation
-  - [ ] Run: `npm run package:local`
-  - [ ] Verify package can be installed and imported
+- [x] **Clean Build**: Clean previous builds
+  - [x] Run: `npm run clean`
+- [x] **Build Package**: Create production build
+  - [x] Run: `npm run build`
+- [x] **Validate Package**: Ensure package is valid
+  - [x] Run: `npm run validate`
+- [x] **Test Package**: Test package installation
+  - [x] Run: `npm run package:local`
+  - [x] Verify package can be installed and imported
 
 #### Documentation
-- [ ] **Create Release Documentation**: Follow the established structure
-  - [ ] Create: `docs/releases/v0.4.0/` directory
-  - [ ] Create: `CHANGELOG.md` with all changes (Keep a Changelog format)
-  - [ ] Create: `MIGRATION.md` if there are breaking changes
-  - [ ] Create: `NEW-FEATURES.md` for new features
-  - [ ] Create: `API-CHANGES.md` for API changes
-  - [ ] Create: `EXAMPLES.md` with usage examples
-- [ ] **Review Documentation**: Review documentation for completeness and accuracy
-  - [ ] Check all examples work correctly
-  - [ ] Verify migration guides are accurate
-  - [ ] Ensure all links are working
-  - [ ] Review for typos and clarity
-- [ ] **Test Documentation Examples**: Test all examples and migration guides
-  - [ ] Test all code examples in NEW-FEATURES.md
-  - [ ] Test all code examples in EXAMPLES.md
-  - [ ] Test migration steps in MIGRATION.md
-  - [ ] Verify API examples in API-CHANGES.md
-- [ ] **Update Main Documentation**: Update README and other docs as needed
-- [ ] **Update Migration Guide**: Update migration documentation if needed
+- [x] **Create Release Documentation**: Follow the established structure
+  - [x] Create: `docs/releases/v0.4.0/` directory
+  - [x] Create: `CHANGELOG.md` with all changes (Keep a Changelog format)
+  - [x] Create: `MIGRATION.md` if there are breaking changes
+  - [x] Create: `NEW-FEATURES.md` for new features
+  - [x] Create: `API-CHANGES.md` for API changes
+  - [x] Create: `EXAMPLES.md` with usage examples
+- [x] **Review Documentation**: Review documentation for completeness and accuracy
+  - [x] Check all examples work correctly
+  - [x] Verify migration guides are accurate
+  - [x] Ensure all links are working
+  - [x] Review for typos and clarity
+- [x] **Test Documentation Examples**: Test all examples and migration guides
+  - [x] Test all code examples in NEW-FEATURES.md
+  - [x] Test all code examples in EXAMPLES.md
+  - [x] Test migration steps in MIGRATION.md
+  - [x] Verify API examples in API-CHANGES.md
+- [x] **Update Main Documentation**: Update README and other docs as needed
+- [x] **Update Migration Guide**: Update migration documentation if needed
 
 #### Git Operations
-- [ ] **Commit Changes**: Commit all release-related changes
-  - [ ] Commit: Version bump and documentation updates
-  - [ ] Message: `chore: prepare release v0.4.0`
-- [ ] **Create Release Branch**: Create a release branch for the version
-  - [ ] Create: `release/v0.4.0` branch
-  - [ ] Push: `git push origin release/v0.4.0`
-- [ ] **Tag Release**: Create git tag for the release
-  - [ ] Tag: `git tag v0.4.0`
-  - [ ] Push: `git push origin v0.4.0`
+- [x] **Commit Changes**: Commit all release-related changes
+  - [x] Commit: Version bump and documentation updates
+  - [x] Message: `chore: prepare release v0.4.0`
+- [x] **Create Release Branch**: Create a release branch for the version
+  - [x] Create: `release/v0.4.0` branch
+  - [x] Push: `git push origin release/v0.4.0`
+- [x] **Tag Release**: Create git tag for the release
+  - [x] Tag: `git tag v0.4.0`
+  - [x] Push: `git push origin v0.4.0`
 
 #### Package Publishing
-- [ ] **Publish to GitHub Registry**: Publish package to GitHub Package Registry
-  - [ ] Run: `npm publish` (automatically publishes to GitHub Registry)
-  - [ ] Verify: Package appears in GitHub Packages
-- [ ] **Verify Installation**: Test package installation from registry
-  - [ ] Test: Install from `@signal-meaning/deepgram-voice-interaction-react@0.4.0`
-  - [ ] Verify: Package works correctly in test environment
+- [x] **Publish to GitHub Registry**: Publish package to GitHub Package Registry
+  - [x] Run: `npm publish` (automatically publishes to GitHub Registry)
+  - [x] Verify: Package appears in GitHub Packages
+- [x] **Verify Installation**: Test package installation from registry
+  - [x] Test: Install from `@signal-meaning/deepgram-voice-interaction-react@0.4.0`
+  - [x] Verify: Package works correctly in test environment
 
 #### GitHub Release
-- [ ] **Create GitHub Release**: Create release on GitHub
-  - [ ] Title: `Release v0.4.0`
-  - [ ] Description: Include changelog and migration notes
-  - [ ] Tag: `v0.4.0`
-  - [ ] Target: `main` branch
-- [ ] **Add Release Labels**: Label the release appropriately
-  - [ ] Add: `release` label
-  - [ ] Add: `v0.4.0` label
-- [ ] **Add Branch Labels**: Label the release branch
-  - [ ] Add: `release` label to `release/v0.4.0` branch
-  - [ ] Add: `v0.4.0` label to `release/v0.4.0` branch
+- [x] **Create GitHub Release**: Create release on GitHub
+  - [x] Title: `Release v0.4.0`
+  - [x] Description: Include changelog and migration notes
+  - [x] Tag: `v0.4.0`
+  - [x] Target: `main` branch
+- [x] **Add Release Labels**: Label the release appropriately
+  - [x] Add: `release` label
+  - [x] Add: `v0.4.0` label
+- [x] **Add Branch Labels**: Label the release branch
+  - [x] Add: `release` label to `release/v0.4.0` branch
+  - [x] Add: `v0.4.0` label to `release/v0.4.0` branch
 
 #### Post-Release
-- [ ] **Update Main Branch**: Merge release branch to main
-  - [ ] Merge: `release/v0.4.0` → `main`
-  - [ ] Push: `git push origin main`
-- [ ] **Clean Up**: Clean up release artifacts
-  - [ ] Remove: Local `.tgz` files
-  - [ ] Remove: Build artifacts if needed
-- [ ] **Announcement**: Announce release (if applicable)
-  - [ ] Update: Any external documentation
-  - [ ] Notify: Relevant teams or users
+- [x] **Update Main Branch**: Merge release branch to main
+  - [x] Merge: `release/v0.4.0` → `main`
+  - [x] Push: `git push origin main`
+- [x] **Clean Up**: Clean up release artifacts
+  - [x] Remove: Local `.tgz` files
+  - [x] Remove: Build artifacts if needed
+- [x] **Announcement**: Announce release (if applicable)
+  - [x] Update: Any external documentation
+  - [x] Notify: Relevant teams or users
 
 ### 🔧 Automated Workflows
 
@@ -153,12 +153,12 @@ Follow the established documentation structure in `docs/releases/`:
 ### ✅ Completion Criteria
 
 This release is complete when:
-- [ ] All checklist items are completed
-- [ ] Package is published to GitHub Registry
-- [ ] GitHub release is created and labeled
-- [ ] Documentation is complete and accurate
-- [ ] All tests are passing
-- [ ] Package installation is verified
+- [x] All checklist items are completed
+- [x] Package is published to GitHub Registry
+- [x] GitHub release is created and labeled
+- [x] Documentation is complete and accurate
+- [x] All tests are passing
+- [x] Package installation is verified
 
 ---
 


### PR DESCRIPTION
Post-release: bring release branch changes into main.

**Included:**
- docs: release template require PR for merge to main; v0.4.0 checklist mark steps done (48bc048)

Release v0.7.11 is already published and the GitHub release is created. This PR syncs the release branch (template + v0.4.0 checklist updates) to main.

Made with [Cursor](https://cursor.com)