### PR TITLE
Merge release/v0.7.11 into main (release template source of truth)

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -11,6 +11,8 @@ CLI Usage:
 gh issue create --template release-checklist.md --title "Release vX.X.X: Complete Release Process and Documentation" --label "release,documentation,priority:high" --body "Replace vX.X.X with actual version number"
 -->
 
+**Use this template for every new release.** Create a new issue from this template (or copy its checklist); do **not** copy from old release folders (e.g. `docs/releases/v0.4.0/RELEASE-CHECKLIST.md`). Those files are archival only and may be outdated; this template is the source of truth.
+
 ## 🚀 Release vX.X.X - Complete Release Process
 
 ### Overview

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -162,10 +162,11 @@ Each release includes a comprehensive checklist to ensure all steps are complete
 
 ### Using the Release Checklist
 
-1. **Create Release Issue**: Use the "Release Checklist" issue template when creating a new release issue
+1. **Create Release Issue**: Use the **"Release Checklist" GitHub issue template** when creating a new release issue
    - Go to GitHub Issues → "New Issue" → Select "Release Checklist" template
    - This automatically includes the complete checklist with proper labels
-2. **Locate the Checklist**: Find the `RELEASE-CHECKLIST.md` file in the version-specific directory (e.g., `docs/releases/v0.4.0/RELEASE-CHECKLIST.md`)
+   - **Use this template as the source of truth.** Do not copy from old release folders (e.g. `docs/releases/v0.4.0/RELEASE-CHECKLIST.md`); those files are archival only and may be outdated.
+2. **Work from the issue**: The checklist lives in the issue you created from the template. Optionally copy it into a version-specific doc (e.g. `docs/issues/ISSUE-NNN/RELEASE-CHECKLIST.md`) if you are tracking a release in an issue folder.
 
 3. **Follow the Process**: Work through each section systematically:
    - **Pre-Release Preparation**: Code review, testing, linting

--- a/docs/releases/v0.4.0/RELEASE-CHECKLIST.md
+++ b/docs/releases/v0.4.0/RELEASE-CHECKLIST.md
@@ -8,96 +8,96 @@ This document tracks the complete release process for version 0.4.0 of the Deepg
 ### 📋 Release Checklist
 
 #### Pre-Release Preparation
-- [x] **Code Review Complete**: All PRs merged and code reviewed
-- [x] **Tests Passing**: All unit tests and E2E tests passing
-  - [x] Run: `npm test`
-  - [x] Run: `npm run test:e2e`
-- [x] **Linting Clean**: No linting errors
-  - [x] Run: `npm run lint`
-- [x] **Documentation Updated**: All relevant documentation updated
-- [x] **Breaking Changes Documented**: Any breaking changes identified and documented
+- [ ] **Code Review Complete**: All PRs merged and code reviewed
+- [ ] **Tests Passing**: All unit tests and E2E tests passing
+  - [ ] Run: `npm test`
+  - [ ] Run: `npm run test:e2e`
+- [ ] **Linting Clean**: No linting errors
+  - [ ] Run: `npm run lint`
+- [ ] **Documentation Updated**: All relevant documentation updated
+- [ ] **Breaking Changes Documented**: Any breaking changes identified and documented
 
 #### Version Management
-- [x] **Bump Version**: Update package.json to 0.4.0
-  - [x] Run: `npm version minor` (or manually update to 0.4.0)
-- [x] **Update Dependencies**: Ensure all dependencies are up to date
-  - [x] Run: `npm update`
-  - [x] Review and update any outdated dependencies
+- [ ] **Bump Version**: Update package.json to 0.4.0
+  - [ ] Run: `npm version minor` (or manually update to 0.4.0)
+- [ ] **Update Dependencies**: Ensure all dependencies are up to date
+  - [ ] Run: `npm update`
+  - [ ] Review and update any outdated dependencies
 
 #### Build and Package
-- [x] **Clean Build**: Clean previous builds
-  - [x] Run: `npm run clean`
-- [x] **Build Package**: Create production build
-  - [x] Run: `npm run build`
-- [x] **Validate Package**: Ensure package is valid
-  - [x] Run: `npm run validate`
-- [x] **Test Package**: Test package installation
-  - [x] Run: `npm run package:local`
-  - [x] Verify package can be installed and imported
+- [ ] **Clean Build**: Clean previous builds
+  - [ ] Run: `npm run clean`
+- [ ] **Build Package**: Create production build
+  - [ ] Run: `npm run build`
+- [ ] **Validate Package**: Ensure package is valid
+  - [ ] Run: `npm run validate`
+- [ ] **Test Package**: Test package installation
+  - [ ] Run: `npm run package:local`
+  - [ ] Verify package can be installed and imported
 
 #### Documentation
-- [x] **Create Release Documentation**: Follow the established structure
-  - [x] Create: `docs/releases/v0.4.0/` directory
-  - [x] Create: `CHANGELOG.md` with all changes (Keep a Changelog format)
-  - [x] Create: `MIGRATION.md` if there are breaking changes
-  - [x] Create: `NEW-FEATURES.md` for new features
-  - [x] Create: `API-CHANGES.md` for API changes
-  - [x] Create: `EXAMPLES.md` with usage examples
-- [x] **Review Documentation**: Review documentation for completeness and accuracy
-  - [x] Check all examples work correctly
-  - [x] Verify migration guides are accurate
-  - [x] Ensure all links are working
-  - [x] Review for typos and clarity
-- [x] **Test Documentation Examples**: Test all examples and migration guides
-  - [x] Test all code examples in NEW-FEATURES.md
-  - [x] Test all code examples in EXAMPLES.md
-  - [x] Test migration steps in MIGRATION.md
-  - [x] Verify API examples in API-CHANGES.md
-- [x] **Update Main Documentation**: Update README and other docs as needed
-- [x] **Update Migration Guide**: Update migration documentation if needed
+- [ ] **Create Release Documentation**: Follow the established structure
+  - [ ] Create: `docs/releases/v0.4.0/` directory
+  - [ ] Create: `CHANGELOG.md` with all changes (Keep a Changelog format)
+  - [ ] Create: `MIGRATION.md` if there are breaking changes
+  - [ ] Create: `NEW-FEATURES.md` for new features
+  - [ ] Create: `API-CHANGES.md` for API changes
+  - [ ] Create: `EXAMPLES.md` with usage examples
+- [ ] **Review Documentation**: Review documentation for completeness and accuracy
+  - [ ] Check all examples work correctly
+  - [ ] Verify migration guides are accurate
+  - [ ] Ensure all links are working
+  - [ ] Review for typos and clarity
+- [ ] **Test Documentation Examples**: Test all examples and migration guides
+  - [ ] Test all code examples in NEW-FEATURES.md
+  - [ ] Test all code examples in EXAMPLES.md
+  - [ ] Test migration steps in MIGRATION.md
+  - [ ] Verify API examples in API-CHANGES.md
+- [ ] **Update Main Documentation**: Update README and other docs as needed
+- [ ] **Update Migration Guide**: Update migration documentation if needed
 
 #### Git Operations
-- [x] **Commit Changes**: Commit all release-related changes
-  - [x] Commit: Version bump and documentation updates
-  - [x] Message: `chore: prepare release v0.4.0`
-- [x] **Create Release Branch**: Create a release branch for the version
-  - [x] Create: `release/v0.4.0` branch
-  - [x] Push: `git push origin release/v0.4.0`
-- [x] **Tag Release**: Create git tag for the release
-  - [x] Tag: `git tag v0.4.0`
-  - [x] Push: `git push origin v0.4.0`
+- [ ] **Commit Changes**: Commit all release-related changes
+  - [ ] Commit: Version bump and documentation updates
+  - [ ] Message: `chore: prepare release v0.4.0`
+- [ ] **Create Release Branch**: Create a release branch for the version
+  - [ ] Create: `release/v0.4.0` branch
+  - [ ] Push: `git push origin release/v0.4.0`
+- [ ] **Tag Release**: Create git tag for the release
+  - [ ] Tag: `git tag v0.4.0`
+  - [ ] Push: `git push origin v0.4.0`
 
 #### Package Publishing
-- [x] **Publish to GitHub Registry**: Publish package to GitHub Package Registry
-  - [x] Run: `npm publish` (automatically publishes to GitHub Registry)
-  - [x] Verify: Package appears in GitHub Packages
-- [x] **Verify Installation**: Test package installation from registry
-  - [x] Test: Install from `@signal-meaning/deepgram-voice-interaction-react@0.4.0`
-  - [x] Verify: Package works correctly in test environment
+- [ ] **Publish to GitHub Registry**: Publish package to GitHub Package Registry
+  - [ ] Run: `npm publish` (automatically publishes to GitHub Registry)
+  - [ ] Verify: Package appears in GitHub Packages
+- [ ] **Verify Installation**: Test package installation from registry
+  - [ ] Test: Install from `@signal-meaning/deepgram-voice-interaction-react@0.4.0`
+  - [ ] Verify: Package works correctly in test environment
 
 #### GitHub Release
-- [x] **Create GitHub Release**: Create release on GitHub
-  - [x] Title: `Release v0.4.0`
-  - [x] Description: Include changelog and migration notes
-  - [x] Tag: `v0.4.0`
-  - [x] Target: `main` branch
-- [x] **Add Release Labels**: Label the release appropriately
-  - [x] Add: `release` label
-  - [x] Add: `v0.4.0` label
-- [x] **Add Branch Labels**: Label the release branch
-  - [x] Add: `release` label to `release/v0.4.0` branch
-  - [x] Add: `v0.4.0` label to `release/v0.4.0` branch
+- [ ] **Create GitHub Release**: Create release on GitHub
+  - [ ] Title: `Release v0.4.0`
+  - [ ] Description: Include changelog and migration notes
+  - [ ] Tag: `v0.4.0`
+  - [ ] Target: `main` branch
+- [ ] **Add Release Labels**: Label the release appropriately
+  - [ ] Add: `release` label
+  - [ ] Add: `v0.4.0` label
+- [ ] **Add Branch Labels**: Label the release branch
+  - [ ] Add: `release` label to `release/v0.4.0` branch
+  - [ ] Add: `v0.4.0` label to `release/v0.4.0` branch
 
 #### Post-Release
-- [x] **Update Main Branch**: Merge release branch to main
-  - [x] Merge: `release/v0.4.0` → `main`
-  - [x] Push: `git push origin main`
-- [x] **Clean Up**: Clean up release artifacts
-  - [x] Remove: Local `.tgz` files
-  - [x] Remove: Build artifacts if needed
-- [x] **Announcement**: Announce release (if applicable)
-  - [x] Update: Any external documentation
-  - [x] Notify: Relevant teams or users
+- [ ] **Update Main Branch**: Merge release branch to main
+  - [ ] Merge: `release/v0.4.0` → `main`
+  - [ ] Push: `git push origin main`
+- [ ] **Clean Up**: Clean up release artifacts
+  - [ ] Remove: Local `.tgz` files
+  - [ ] Remove: Build artifacts if needed
+- [ ] **Announcement**: Announce release (if applicable)
+  - [ ] Update: Any external documentation
+  - [ ] Notify: Relevant teams or users
 
 ### 🔧 Automated Workflows
 
@@ -153,12 +153,12 @@ Follow the established documentation structure in `docs/releases/`:
 ### ✅ Completion Criteria
 
 This release is complete when:
-- [x] All checklist items are completed
-- [x] Package is published to GitHub Registry
-- [x] GitHub release is created and labeled
-- [x] Documentation is complete and accurate
-- [x] All tests are passing
-- [x] Package installation is verified
+- [ ] All checklist items are completed
+- [ ] Package is published to GitHub Registry
+- [ ] GitHub release is created and labeled
+- [ ] Documentation is complete and accurate
+- [ ] All tests are passing
+- [ ] Package installation is verified
 
 ---
 


### PR DESCRIPTION
Post-release: use release template as source of truth; do not copy from archival docs.

**Changes:**
- **Template** (.github/ISSUE_TEMPLATE/release-checklist.md): Note at top — use this template for every new release; do not copy from old release folders (e.g. v0.4.0); this template is source of truth.
- **README** (docs/releases/README.md): Using the Release Checklist now points to the GitHub issue template, not version-specific archival files.
- **v0.4.0** (docs/releases/v0.4.0/RELEASE-CHECKLIST.md): Reverted to unchecked steps; file is archival only.

Made with [Cursor](https://cursor.com)