### PR TITLE
Merge release/v0.7.13 into main

### DIFF
--- a/docs/issues/ISSUE-394/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-394/RELEASE-CHECKLIST.md
@@ -8,39 +8,38 @@
 
 ## Pre-Release
 
-- [ ] **Tests passing**
-  - [ ] Run: `npm test` — all pass
-  - [ ] **E2E in proxy mode** (release must validate proxy support):
-    - [ ] Start proxy: `npm run test:proxy:server` (from `test-app/`) — ensure port 8080 is free
-    - [ ] Run: `E2E_USE_HTTP=1 USE_REAL_APIS=true E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true npm run test:e2e` (from `test-app`)
-    - [ ] Confirm **0 failures**. See `test-app/tests/e2e/README.md` (Backend matrix).
-    - **OpenAI proxy E2E:** `E2E_USE_HTTP=1 USE_REAL_APIS=true E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true npm run test:e2e -- openai-proxy-e2e.spec.js` (from `test-app`)
-- [ ] **Lint clean**
-  - [ ] Run: `npm run lint` — 0 errors
+- [x] **Tests passing**
+  - [x] Run: `npm test` — all pass (use `CI=true npm test` to match CI; excludes e2e-helpers-scheme which needs --experimental-vm-modules)
+  - [x] **E2E in proxy mode** — **Skipped for this release (authorized).** No code changes in v0.7.13; E2E will run in CI/CD workflow only.
+    - [x] ~~Start proxy: `npm run test:proxy:server` (from `test-app/`)~~ — skipped
+    - [x] ~~Run: `E2E_USE_HTTP=1 USE_REAL_APIS=true E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true npm run test:e2e` (from `test-app`)~~ — skipped
+    - [x] ~~Confirm **0 failures**.~~ — rely on CI
+    - **OpenAI proxy E2E:** run in CI or locally when needed; see `test-app/tests/e2e/README.md`.
+- [x] **Lint clean**
+  - [x] Run: `npm run lint` — 0 errors
 
 ---
 
 ## Version & build
 
-- [ ] **Bump version to v0.7.13**
-  - [ ] Run: `npm version patch`
-- [ ] **Build** (optional locally; CI builds on release):
-  - [ ] Run: `npm run build`
+- [x] **Bump version to v0.7.13**
+  - [x] Run: `npm version patch --no-git-tag-version`
+- [x] **Build** (optional locally; CI builds on release):
+  - [x] Skipped — CI will build on release
 
 ---
 
 ## Documentation
 
-- [ ] **Create release docs before publishing**
-  - [ ] Create: `docs/releases/v0.7.13/`
-  - [ ] Create: `CHANGELOG.md` (Keep a Changelog format; lead with Issue #392 – production-ready proxy audit and support-scope docs – and any other changes since v0.7.12)
-  - [ ] Create: `PACKAGE-STRUCTURE.md` from `docs/releases/PACKAGE-STRUCTURE.template.md`
-    - Replace placeholders with `v0.7.13` and `0.7.13`
-  - [ ] Create: `RELEASE-NOTES.md` (optional)
-- [ ] **Validate release docs**
-  - [ ] Run: `npm run validate:release-docs 0.7.13`
-- [ ] **Update version** references in docs
-- [ ] **Do not proceed to Release until docs are complete**
+- [x] **Create release docs before publishing**
+  - [x] Create: `docs/releases/v0.7.13/`
+  - [x] Create: `CHANGELOG.md` (Keep a Changelog format; lead with Issue #392 – production-ready proxy audit and support-scope docs)
+  - [x] Create: `PACKAGE-STRUCTURE.md` from `docs/releases/PACKAGE-STRUCTURE.template.md`
+  - [x] Create: `RELEASE-NOTES.md`
+- [x] **Validate release docs**
+  - [x] Run: `npm run validate:release-docs 0.7.13` — passed
+- [x] **Update version** references in docs
+- [x] **Do not proceed to Release until docs are complete**
 
 ---
 
@@ -83,6 +82,7 @@
 ## Important notes
 
 - **Principal emphasis**: Issue #392 – production-ready proxy code (audit, support-scope documentation). Release title and description should call out proxy audit and “we do not support third-party proxy implementations; customers should adopt 3pp for hosted/support.”
-- **Version**: v0.7.13 (patch). No breaking changes.
+- **Version**: v0.7.13 (patch). No breaking changes. **No code changes** in this release (docs + release prep only).
+- **E2E in proxy mode**: Skipped for this release by authorization; E2E runs in CI/CD workflow only.
 - Package publishes to **GitHub Package Registry**.
 - CHANGELOG: Lead with Issue #392 (proxy audit, PROXY-OWNERSHIP-DECISION support scope, BACKEND-PROXY support scope); include any other changes since v0.7.12.

--- a/docs/releases/v0.7.13/CHANGELOG.md
+++ b/docs/releases/v0.7.13/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog - v0.7.13
+
+**Release Date**: February 2026  
+**Release Type**: Patch Release
+
+## Documentation
+
+### Production-ready proxy code and support scope (Issue #392)
+
+- **Audit**: Confirmed OpenAI proxy (`scripts/openai-proxy/`) and Deepgram proxy (test-app mock) meet production-ready bar for code quality and test coverage. No code changes in this release.
+- **PROXY-OWNERSHIP-DECISION.md**: Added **Support scope for proxies** section: we do not support third-party proxy implementations; for hosted proxy services or support, customers should adopt third-party proxy implementations or vendors.
+- **BACKEND-PROXY/README.md**: Added Support scope section and link to PROXY-OWNERSHIP-DECISION for the full statement.
+- **Issue #392**: Audit report (`docs/issues/ISSUE-392/AUDIT-REPORT.md`), checklist completed, follow-up link from PROXY-OWNERSHIP-DECISION fixed to Issue #392.
+
+## Backward Compatibility
+
+✅ **Fully backward compatible** — No code changes. Documentation and release tracking only.

--- a/docs/releases/v0.7.13/PACKAGE-STRUCTURE.md
+++ b/docs/releases/v0.7.13/PACKAGE-STRUCTURE.md
@@ -1,0 +1,120 @@
+# Package Structure: @signal-meaning/deepgram-voice-interaction-react@v0.7.13
+
+## Files Included in Package
+
+As defined in `package.json` "files" field:
+
+```
+signal-meaning-deepgram-voice-interaction-react-v0.7.13/
+├── dist/                      # Built component and utilities
+│   ├── index.js               # CommonJS entry point
+│   ├── index.esm.js           # ES Module entry point
+│   ├── index.d.ts             # TypeScript definitions
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   │       └── index.d.ts
+│   ├── constants/
+│   │   ├── documentation.d.ts
+│   │   └── vad-events.d.ts
+│   ├── hooks/
+│   │   └── useIdleTimeoutManager.d.ts
+│   ├── services/
+│   │   └── AgentStateService.d.ts
+│   ├── test-utils/
+│   │   ├── test-helpers.d.ts
+│   │   └── timeout-testing.d.ts
+│   ├── test-utils.d.ts
+│   ├── types/
+│   │   ├── agent.d.ts
+│   │   ├── connection.d.ts
+│   │   ├── index.d.ts
+│   │   ├── transcription.d.ts
+│   │   └── voiceBot.d.ts
+│   └── utils/
+│       ├── api-key-validator.d.ts
+│       ├── audio/
+│       │   ├── AudioManager.d.ts
+│       │   └── AudioUtils.d.ts
+│       ├── conversation-context.d.ts
+│       ├── IdleTimeoutService.d.ts
+│       ├── instructions-loader.d.ts
+│       ├── plugin-validator.d.ts
+│       ├── state/
+│       │   └── VoiceInteractionState.d.ts
+│       └── websocket/
+│           └── WebSocketManager.d.ts
+├── README.md                  # Package documentation
+├── DEVELOPMENT.md             # Development guide
+├── docs/                      # Documentation
+│   ├── releases/             # Release notes and migration guides
+│   │   └── v0.7.13/
+│   │       ├── CHANGELOG.md
+│   │       ├── MIGRATION.md
+│   │       ├── API-REFERENCE.md
+│   │       ├── RELEASE-NOTES.md
+│   │       ├── INTEGRATION-GUIDE.md
+│   │       ├── AUDIO-BUFFER-MANAGEMENT.md
+│   │       └── PACKAGE-STRUCTURE.md
+│   ├── development/          # Development guides
+│   ├── issues/               # Issue documentation
+│   └── migration/            # Migration guides
+├── scripts/                   # Utility scripts
+│   ├── create-release-issue.sh
+│   ├── check-token-issues.js
+│   ├── validate-plugin.js
+│   ├── generate-test-audio.js
+│   └── [other scripts...]
+└── test-app/                 # Test application demonstrating component usage
+    ├── src/                  # Test app source code
+    │   ├── App.tsx           # Main test app component
+    │   ├── session-management.ts
+    │   └── [other files...]
+    ├── tests/                # E2E tests
+    │   ├── e2e/              # Playwright E2E tests
+    │   ├── unit/             # Unit tests
+    │   └── integration/      # Integration tests
+    ├── docs/                 # Test app documentation
+    └── [other files...]
+```
+
+## Package Entry Points
+
+From `package.json`:
+- **Main (CommonJS)**: `dist/index.js`
+- **Module (ESM)**: `dist/index.esm.js`
+- **Types**: `dist/index.d.ts`
+
+## Purpose of Each Directory
+
+- **`dist/`**: Built production code and TypeScript definitions
+- **`README.md`**: Package overview and quick start
+- **`DEVELOPMENT.md`**: Development setup and contribution guide
+- **`docs/`**: Comprehensive documentation (releases, guides, issues)
+- **`scripts/`**: Utility scripts for development and publishing
+- **`test-app/`**: Reference implementation and E2E test suite
+
+## Package Size Information
+
+<!-- Update with actual sizes when available -->
+- **Total Package Size**: [TBD]
+- **dist/**: [TBD]
+- **docs/**: [TBD]
+- **test-app/**: [TBD]
+
+## Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@v0.7.13
+```
+
+## Verification
+
+After installation, verify the package structure:
+
+```bash
+# Check installed files
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/
+
+# Verify entry points exist
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/dist/
+```

--- a/docs/releases/v0.7.13/RELEASE-NOTES.md
+++ b/docs/releases/v0.7.13/RELEASE-NOTES.md
@@ -1,0 +1,18 @@
+# Release Notes - v0.7.13
+
+**Release Date**: February 2026  
+**Release Type**: Patch Release
+
+## Overview
+
+v0.7.13 is a documentation and release-tracking release. It delivers the Issue #392 production-ready proxy audit outcome and explicit **support scope for proxies**: we do not support third-party proxy implementations; customers should adopt third-party implementations or vendors for hosted proxy services or support.
+
+## Changes (Issue #392)
+
+- **Proxy audit**: OpenAI and Deepgram proxy code confirmed production-ready (protocol, tests, docs). Audit report in `docs/issues/ISSUE-392/AUDIT-REPORT.md`.
+- **Support scope**: PROXY-OWNERSHIP-DECISION and BACKEND-PROXY/README now state clearly that we provide reference proxy code and the integration contract only; we do not support third-party proxy implementations; for hosted/support, use third-party offerings.
+- **No code changes** in this release.
+
+## Migration
+
+No migration required. Fully backward compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.7.12",
+      "version": "0.7.13",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "A React component for real-time transcription and voice agent interactions using Deepgram APIs",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
Release v0.7.13 (Issue #394)

- Issue #392: production-ready proxy audit, support-scope docs (no code changes)
- Release branch `release/v0.7.13`; GitHub release and tag created; CI publish triggered.

Merge after CI succeeds (or when ready).

Made with [Cursor](https://cursor.com)