### PR TITLE
Merge release/v0.7.14 into main

### DIFF
--- a/docs/SOURCE-REFERENCE.md
+++ b/docs/SOURCE-REFERENCE.md
@@ -1,0 +1,51 @@
+# Source reference – component and proxy
+
+This document directs you to the **major source elements** in this package so you can use the shipped source as a reference implementation. The package includes both built output (`dist/`) and source (`src/`, `scripts/`).
+
+---
+
+## Component (React)
+
+| Purpose | Location | Notes |
+|--------|----------|--------|
+| **Entry point** | `src/index.ts` | Exports `DeepgramVoiceInteraction`, types, and test utilities. |
+| **Main component** | `src/components/DeepgramVoiceInteraction/index.tsx` | Headless React component: WebSocket lifecycle, agent/transcription options, callbacks (e.g. `onFunctionCallRequest`), ref methods. |
+| **Built output** | `dist/index.js`, `dist/index.esm.js`, `dist/index.d.ts` | Use these at runtime; `src/` is for reference and debugging. |
+| **Types** | `src/types/` | Connection, agent, transcription, and related TypeScript types. |
+| **Hooks / utils** | `src/hooks/`, `src/utils/`, `src/services/` | Used by the component (e.g. idle timeout, WebSocket handling). |
+
+---
+
+## OpenAI Realtime proxy
+
+The proxy translates between the **component protocol** (e.g. Settings, InjectUserMessage, ConversationText) and the **OpenAI Realtime API** (session.update, conversation.item.create, response.create, etc.). It runs as a WebSocket server that clients connect to; it then connects to the OpenAI Realtime upstream.
+
+| File | Purpose |
+|------|--------|
+| **`scripts/openai-proxy/server.ts`** | WebSocket server: accepts component protocol, translates to OpenAI client events, forwards to upstream, translates upstream events back to component. Handles **event ordering**: on `InjectUserMessage` it sends `conversation.item.create` to upstream and sends `response.create` **only after** upstream sends `conversation.item.added` or `conversation.item.done` (required by the OpenAI API so the connection stays open). Also handles binary audio (e.g. `input_audio_buffer.append`), greeting injection after session.updated, and FunctionCallRequest/FunctionCallResponse mapping. |
+| **`scripts/openai-proxy/translator.ts`** | Pure mapping functions: component messages ↔ OpenAI Realtime events (e.g. Settings → session.update, InjectUserMessage → conversation.item.create, response.output_text.done → ConversationText, response.function_call_arguments.done → FunctionCallRequest). |
+| **`scripts/openai-proxy/run.ts`** | Entry point to run the proxy (loads env, starts HTTP server, attaches WebSocket at a path). Use `npm run openai-proxy` from the package root. |
+| **`scripts/openai-proxy/logger.ts`** | Optional OpenTelemetry-style logging when `OPENAI_PROXY_DEBUG=1`. |
+| **`scripts/openai-proxy/README.md`** | Translator exports, server behavior, and how to run the proxy. |
+
+**Important behavior (event order):** For text messages injected via the component (`InjectUserMessage`), the proxy must send `response.create` to OpenAI **only after** the upstream has sent `conversation.item.added` or `conversation.item.done`. Sending `response.create` immediately after `conversation.item.create` can cause the upstream to close the connection. See `docs/issues/ISSUE-388/OPENAI-REALTIME-API-REVIEW.md` for the API rationale.
+
+---
+
+## Deepgram proxy (test-app)
+
+For Deepgram-backed flows, the test-app includes a **mock proxy server** that forwards WebSocket traffic to the Deepgram Voice Agent API (or transcription) and adds API key server-side. It does not translate protocols; it is a passthrough with routing and auth.
+
+| Location | Purpose |
+|----------|--------|
+| **`test-app/scripts/mock-proxy-server.js`** | Single server that can expose `/deepgram-proxy` (Deepgram) and/or `/openai` (forwards to the OpenAI proxy subprocess). Used for E2E and local testing. |
+| **`test-app/docs/PROXY-SERVER.md`** | Design, operation, and usage of the mock proxy server. |
+
+---
+
+## Further documentation
+
+- **API surface:** `docs/API-REFERENCE.md`
+- **Backend proxy (interface contract):** `docs/BACKEND-PROXY/README.md`, `docs/BACKEND-PROXY/INTERFACE-CONTRACT.md`
+- **OpenAI proxy event order:** `docs/issues/ISSUE-388/OPENAI-REALTIME-API-REVIEW.md`
+- **Proxy ownership and support scope:** `docs/issues/ISSUE-388/PROXY-OWNERSHIP-DECISION.md`

--- a/docs/issues/ISSUE-397/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-397/RELEASE-CHECKLIST.md
@@ -1,0 +1,84 @@
+# Release Checklist – Issue #397
+
+**Release v0.7.14** – customer solution: **include source in package** (especially proxy source), **source reference documentation** directing customers to major source elements, and **simple release docs**.
+
+**GitHub issue:** [Issue #397](https://github.com/Signal-Meaning/dg_react_agent/issues/397)
+
+---
+
+## Deliverables (scope)
+
+1. **Source in package** — [x] Added `src/` to `package.json` `"files"`; `scripts/openai-proxy/` already included via `scripts/`.
+2. **Source reference documentation** — [x] `docs/SOURCE-REFERENCE.md` added (component + proxy source, event order, links).
+3. **Simple release docs** — [x] `docs/releases/v0.7.14/`: CHANGELOG, RELEASE-NOTES, PACKAGE-STRUCTURE; validated.
+
+---
+
+## Pre-Release
+
+- [x] **Tests passing**
+  - [x] Run: `npm test` (use `CI=true npm test` to match CI) — 75 suites, 817 passed
+- [x] **Lint clean**
+  - [x] Run: `npm run lint` — 0 errors
+- [ ] **E2E in proxy mode** (optional for this release): skipped for now
+
+---
+
+## Version & build
+
+- [x] **Bump version to v0.7.14**
+  - [x] Run: `npm version patch --no-git-tag-version`
+- [x] **Build** (CI builds on release; optional local verify)
+  - [x] Skipped — CI will build on release
+
+---
+
+## Documentation
+
+- [x] **Source reference doc** (deliverable 2)
+  - [x] Created `docs/SOURCE-REFERENCE.md`: component entry, proxy (server.ts, translator.ts, run.ts, logger.ts), event order explanation, Deepgram test-app proxy; links to API-REFERENCE, BACKEND-PROXY, OPENAI-REALTIME-API-REVIEW, PROXY-OWNERSHIP-DECISION.
+- [x] **Release docs** (deliverable 3)
+  - [x] Create: `docs/releases/v0.7.14/`
+  - [x] Create: `CHANGELOG.md`, `RELEASE-NOTES.md`, `PACKAGE-STRUCTURE.md`
+- [x] **Validate release docs**
+  - [x] Run: `npm run validate:release-docs 0.7.14` — passed
+- [x] **Do not proceed to Release until docs are complete**
+
+---
+
+## Release
+
+- [ ] **Commit release prep**
+  - [ ] Commit: version bump, `package.json` `files` (add `src/`), source reference doc, release docs
+  - [ ] Message: `chore: prepare release v0.7.14 (source in package, source reference docs)`
+- [ ] **Release branch**
+  - [ ] `git checkout -b release/v0.7.14`
+  - [ ] `git push origin release/v0.7.14`
+- [ ] **Publish**
+  - [ ] Create GitHub release to trigger CI (`.github/workflows/test-and-publish.yml`)
+  - [ ] Monitor Actions; confirm package in GitHub Packages
+  - [ ] Tag created with release (v0.7.14)
+- [ ] **GitHub release**
+  - [ ] Title: `v0.7.14`; description from CHANGELOG.md
+  - [ ] Target: `release/v0.7.14`
+- [ ] **Post-release**
+  - [ ] Merge `release/v0.7.14` → `main` via PR
+
+---
+
+## Completion criteria
+
+- [ ] Package includes `src/` and proxy source; customers can use shipped source as reference.
+- [ ] Source reference documentation added/updated and in package.
+- [ ] Package published to GitHub Package Registry.
+- [ ] GitHub release v0.7.14 created.
+- [ ] Release docs in `docs/releases/v0.7.14/` complete and validated.
+
+---
+
+## Important notes
+
+- **Focus:** Customer solution — ship source (especially proxy) and direct customers to it via source reference docs. No change to proxy ownership/support scope in this release.
+- **Version:** v0.7.14 (patch). Backward compatible; additive (more files in package, new/updated docs).
+- Package publishes to **GitHub Package Registry**.
+- CHANGELOG: Lead with “source in package” and “source reference documentation”; reference Issue #397.

--- a/docs/releases/v0.7.14/CHANGELOG.md
+++ b/docs/releases/v0.7.14/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog - v0.7.14
+
+**Release Date**: February 2026  
+**Release Type**: Patch Release
+
+## Added (Issue #397)
+
+### Source included in package
+
+- **Component source**: The published package now includes `src/` (component TypeScript source) in addition to built output (`dist/`). Entry point: `src/index.ts`; main component: `src/components/DeepgramVoiceInteraction/index.tsx`. Use `dist/` at runtime; use `src/` for reference or debugging.
+- **Proxy source**: The package already included `scripts/` (e.g. `scripts/openai-proxy/`). This release makes it explicit that proxy source is part of the customer-facing reference (server, translator, run, logger).
+
+### Source reference documentation
+
+- **`docs/SOURCE-REFERENCE.md`**: New document that directs customers to the major source elements:
+  - **Component**: `src/index.ts`, `src/components/DeepgramVoiceInteraction/`, `dist/` entry points, types, hooks, utils.
+  - **OpenAI Realtime proxy**: `scripts/openai-proxy/server.ts` (WebSocket server, event ordering), `translator.ts` (mapping), `run.ts` (entry), `logger.ts` (optional debug). Includes a short explanation of what is built there (protocol translation, InjectUserMessage → response.create only after conversation.item.added/conversation.item.done).
+  - **Deepgram proxy (test-app)**: `test-app/scripts/mock-proxy-server.js`, with pointer to `test-app/docs/PROXY-SERVER.md`.
+  - Links to API-REFERENCE, BACKEND-PROXY, OPENAI-REALTIME-API-REVIEW, and PROXY-OWNERSHIP-DECISION.
+
+## Backward Compatibility
+
+✅ **Fully backward compatible** — Additive only. New files in package (`src/`, `docs/SOURCE-REFERENCE.md`); no API or behavior changes. Existing consumers continue to use `dist/` as before.

--- a/docs/releases/v0.7.14/PACKAGE-STRUCTURE.md
+++ b/docs/releases/v0.7.14/PACKAGE-STRUCTURE.md
@@ -1,0 +1,114 @@
+# Package Structure: @signal-meaning/deepgram-voice-interaction-react@v0.7.14
+
+## Files Included in Package
+
+As defined in `package.json` "files" field:
+
+```
+signal-meaning-deepgram-voice-interaction-react-v0.7.14/
+├── dist/                      # Built component and utilities
+│   ├── index.js               # CommonJS entry point
+│   ├── index.esm.js           # ES Module entry point
+│   ├── index.d.ts             # TypeScript definitions
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   │       └── index.d.ts
+│   ├── constants/
+│   │   ├── documentation.d.ts
+│   │   └── vad-events.d.ts
+│   ├── hooks/
+│   │   └── useIdleTimeoutManager.d.ts
+│   ├── services/
+│   │   └── AgentStateService.d.ts
+│   ├── test-utils/
+│   │   ├── test-helpers.d.ts
+│   │   └── timeout-testing.d.ts
+│   ├── test-utils.d.ts
+│   ├── types/
+│   │   ├── agent.d.ts
+│   │   ├── connection.d.ts
+│   │   ├── index.d.ts
+│   │   ├── transcription.d.ts
+│   │   └── voiceBot.d.ts
+│   └── utils/
+│       ├── api-key-validator.d.ts
+│       ├── audio/
+│       │   ├── AudioManager.d.ts
+│       │   └── AudioUtils.d.ts
+│       ├── conversation-context.d.ts
+│       ├── IdleTimeoutService.d.ts
+│       ├── instructions-loader.d.ts
+│       ├── plugin-validator.d.ts
+│       ├── state/
+│       │   └── VoiceInteractionState.d.ts
+│       └── websocket/
+│           └── WebSocketManager.d.ts
+├── src/                       # Component source (reference; use dist/ at runtime)
+│   ├── index.ts
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   ├── types/
+│   ├── hooks/
+│   ├── services/
+│   ├── utils/
+│   └── ...
+├── README.md                  # Package documentation
+├── DEVELOPMENT.md             # Development guide
+├── docs/                      # Documentation
+│   ├── SOURCE-REFERENCE.md    # Points to component and proxy source (v0.7.14+)
+│   ├── releases/
+│   │   └── v0.7.14/
+│   │       ├── CHANGELOG.md
+│   │       ├── RELEASE-NOTES.md
+│   │       └── PACKAGE-STRUCTURE.md
+│   ├── development/
+│   ├── issues/
+│   └── migration/
+├── scripts/                   # Utility scripts and proxy source
+│   ├── openai-proxy/          # OpenAI Realtime proxy (server, translator, run, logger)
+│   ├── create-release-issue.sh
+│   └── [other scripts...]
+└── test-app/                  # Test application and mock proxy
+    ├── src/
+    ├── scripts/               # mock-proxy-server.js (Deepgram / OpenAI)
+    ├── tests/
+    └── docs/
+```
+
+## Package Entry Points
+
+From `package.json`:
+- **Main (CommonJS)**: `dist/index.js`
+- **Module (ESM)**: `dist/index.esm.js`
+- **Types**: `dist/index.d.ts`
+
+## Purpose of Each Directory
+
+- **`dist/`**: Built production code and TypeScript definitions (use at runtime).
+- **`src/`**: Component source for reference (v0.7.14+); see `docs/SOURCE-REFERENCE.md`.
+- **`README.md`**: Package overview and quick start.
+- **`DEVELOPMENT.md`**: Development setup and contribution guide.
+- **`docs/`**: Documentation (including SOURCE-REFERENCE.md, releases, guides, issues).
+- **`scripts/`**: Proxy implementation (`openai-proxy/`) and utility scripts.
+- **`test-app/`**: Reference app and E2E tests; mock proxy server.
+
+## Installation
+
+```bash
+npm install @signal-meaning/deepgram-voice-interaction-react@v0.7.14
+```
+
+## Verification
+
+After installation, verify the package structure:
+
+```bash
+# Check installed files (including src/)
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/
+
+# Verify entry points
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/dist/
+
+# Verify source reference doc
+ls node_modules/@signal-meaning/deepgram-voice-interaction-react/docs/SOURCE-REFERENCE.md
+```

--- a/docs/releases/v0.7.14/RELEASE-NOTES.md
+++ b/docs/releases/v0.7.14/RELEASE-NOTES.md
@@ -1,0 +1,26 @@
+# Release Notes - v0.7.14
+
+**Release Date**: February 2026  
+**Release Type**: Patch Release
+
+## Overview
+
+v0.7.14 adds **source to the published package** and **source reference documentation** so customers can use the shipped source as the reference implementation, especially for the proxy.
+
+## Changes (Issue #397)
+
+1. **Source in package**  
+   - `package.json` `"files"` now includes `src/`. The package ships component source in addition to `dist/`, `docs/`, `scripts/`, and `test-app/`. Proxy source remains in `scripts/openai-proxy/`.
+
+2. **Source reference doc**  
+   - **`docs/SOURCE-REFERENCE.md`** points customers to:
+     - Component: `src/index.ts`, main component, types, hooks, utils; built entry points in `dist/`.
+     - OpenAI proxy: `server.ts`, `translator.ts`, `run.ts`, `logger.ts` with a brief explanation (protocol translation, event order: `response.create` only after `conversation.item.added` / `conversation.item.done`).
+     - Deepgram proxy (test-app) and links to further docs.
+
+3. **No behavior or API changes**  
+   - Runtime behavior and public API are unchanged. This release is additive (more files, new doc).
+
+## Migration
+
+No migration required. Fully backward compatible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@signal-meaning/deepgram-voice-interaction-react",
-      "version": "0.7.13",
+      "version": "0.7.14",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@signal-meaning/deepgram-voice-interaction-react",
-  "version": "0.7.13",
+  "version": "0.7.14",
   "description": "A React component for real-time transcription and voice agent interactions using Deepgram APIs",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "files": [
     "dist",
+    "src",
     "README.md",
     "DEVELOPMENT.md",
     "docs/",


### PR DESCRIPTION
Release v0.7.14 (Issue #397)

- Source in package: add src/ to package.json files; proxy source in scripts/
- Source reference: docs/SOURCE-REFERENCE.md (component + proxy, event order)
- Release docs: docs/releases/v0.7.14 (CHANGELOG, RELEASE-NOTES, PACKAGE-STRUCTURE)
- GitHub release and tag v0.7.14 created; CI publish triggered.

Made with [Cursor](https://cursor.com)