### PR TITLE
fix: invoke onSettingsApplied when session.created is received (fixes #428)

### DIFF
--- a/docs/issues/ISSUE-428/README.md
+++ b/docs/issues/ISSUE-428/README.md
@@ -1,0 +1,35 @@
+# Issue #428: OpenAI proxy path — invoke onSettingsApplied when session.created is received
+
+**Branch:** `davidrmcgee/issue428`  
+**GitHub:** [#428](https://github.com/Signal-Meaning/dg_react_agent/issues/428)  
+**Severity:** Critical
+
+---
+
+## Summary
+
+When the backend (OpenAI proxy) sends a **`session.created`** message over the WebSocket, the component does not invoke **`onSettingsApplied`**. Consumers (e.g. voice-commerce) rely on `onSettingsApplied` as the readiness signal before sending user messages. For the Deepgram path the component already invokes `onSettingsApplied` when **`SettingsApplied`** is received; the OpenAI proxy path should do the same when **`session.created`** is received (so both providers expose a single readiness contract).
+
+---
+
+## Requested fix
+
+In the component’s message-handling path, when a WebSocket message of type **`session.created`** is received, call the **`onSettingsApplied`** prop (if provided) and update internal “settings applied” state the same way as for **`SettingsApplied`**, so that app and E2E can treat “session created” as the readiness signal for the OpenAI proxy path.
+
+---
+
+## Docs in this directory
+
+| Doc | Purpose |
+|-----|--------|
+| [README.md](./README.md) | This file — issue summary. |
+| [RESOLUTION.md](./RESOLUTION.md) | Resolution plan: location, TDD steps, and implementation notes. |
+
+---
+
+## References
+
+- Bug report body: [../OPENAI-PROXY-BUG-1-BODY.md](../OPENAI-PROXY-BUG-1-BODY.md)
+- Deepgram path: `SettingsApplied` handling in `src/components/DeepgramVoiceInteraction/index.tsx` (~lines 2179–2192)
+- OpenAI proxy protocol: `scripts/openai-proxy/PROTOCOL-AND-MESSAGE-ORDERING.md` (session.created vs session.updated)
+- Related: Issue #414 (proxy/client protocol), Issue #406 (SettingsApplied and session.updated)

--- a/docs/issues/ISSUE-428/RESOLUTION.md
+++ b/docs/issues/ISSUE-428/RESOLUTION.md
@@ -1,0 +1,75 @@
+# Issue #428 — Resolution plan: onSettingsApplied on session.created
+
+**Branch:** `davidrmcgee/issue428`
+
+---
+
+## Goal
+
+When the component receives a WebSocket message with **`type === 'session.created'`**, treat it as the OpenAI-proxy readiness signal and:
+
+1. Update internal “settings applied” state (e.g. `hasSentSettingsRef`, `SETTINGS_SENT` dispatch) the same way as for `SettingsApplied`.
+2. Call **`onSettingsApplied`** (if provided).
+
+No change to Deepgram path: continue to invoke `onSettingsApplied` only when **`SettingsApplied`** is received.
+
+---
+
+## Location of change
+
+**File:** `src/components/DeepgramVoiceInteraction/index.tsx`
+
+**Existing block to mirror:** The `SettingsApplied` handler (around lines 2179–2192):
+
+- `if (data.type === 'SettingsApplied') { ... hasSentSettingsRef.current = true; ... dispatch({ type: 'SETTINGS_SENT', sent: true }); ... onSettingsApplied?.(); return; }`
+
+**Add:** A similar block for **`session.created`** that performs the same state updates and calls `onSettingsApplied?.()`. Place it immediately after the `SettingsApplied` block (or combine with a shared helper / `type === 'SettingsApplied' || data.type === 'session.created'` and one block) so behavior is consistent and DRY.
+
+**Recommendation:** One conditional: `if (data.type === 'SettingsApplied' || data.type === 'session.created')` with a single block (and optional log line that distinguishes “SettingsApplied” vs “session.created” for debugging). That keeps one place for “readiness signal” logic.
+
+---
+
+## TDD workflow (mandatory)
+
+1. **RED — Tests first**
+   - **Unit test:** In the component’s test suite, add (or extend) a test that simulates a WebSocket message with `type: 'session.created'` and asserts that `onSettingsApplied` is called exactly once and that internal “settings applied” state is updated (e.g. ref or state used by “safe to send” logic).
+   - **Integration test (if applicable):** If there is an OpenAI proxy integration test that receives messages from a mock proxy, add or adjust a case where the mock sends `session.created` and assert that the component invokes `onSettingsApplied` (or that the test app’s readiness signal is set).
+   - Run tests and confirm they **fail** before implementation.
+
+2. **GREEN — Implement**
+   - In `DeepgramVoiceInteraction/index.tsx`, in the same message-handling switch/chain where `SettingsApplied` is handled, add handling for `session.created` so that:
+     - The same ref/state updates as for `SettingsApplied` are performed.
+     - `onSettingsApplied?.()` is called.
+   - Prefer a single block for both `SettingsApplied` and `session.created` to avoid duplication.
+
+3. **REFACTOR**
+   - If needed, extract a small helper (e.g. `handleSettingsReadinessSignal()`) and call it from both branches; ensure tests still pass.
+
+4. **Re-run**
+   - Full unit and integration tests; confirm no regressions on Deepgram path (SettingsApplied still triggers `onSettingsApplied`).
+
+---
+
+## Acceptance criteria
+
+- [x] When a message with `type === 'session.created'` is received, `onSettingsApplied` is called (if the prop is provided).
+- [x] Internal “settings applied” state (e.g. `hasSentSettingsRef`, `SETTINGS_SENT`) is updated for `session.created` the same way as for `SettingsApplied`.
+- [x] Existing behavior for `SettingsApplied` is unchanged (Deepgram path).
+- [x] Unit test(s) cover `session.created` → `onSettingsApplied` and any shared state.
+- [x] No new linter/type errors; existing tests remain green.
+
+---
+
+## Types / protocol
+
+- **Deepgram:** Server sends `SettingsApplied` when settings are applied.
+- **OpenAI proxy:** Backend may send `session.created` (or the proxy may translate upstream `session.updated` to `SettingsApplied` to the client). The component should treat **both** `SettingsApplied` and `session.created` as readiness signals so that different backends (pure Deepgram vs OpenAI proxy) work without app changes.
+
+If the codebase has a shared type for “readiness” message types, consider adding `'session.created'` there for clarity; otherwise a simple `data.type === 'session.created'` in the handler is sufficient.
+
+---
+
+## Out of scope for this issue
+
+- Changing what the **proxy** sends (proxy may continue to send either `SettingsApplied` or `session.created`; component supports both).
+- Issue #429 (agentManagerRef / disableIdleTimeoutResets for OpenAI path) — separate branch/PR.

--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -2176,19 +2176,19 @@ function DeepgramVoiceInteraction(
       return;
     }
     
-    // Handle SettingsApplied message - settings are now active
-    if (data.type === 'SettingsApplied') {
-      logger.info('✅ [Protocol] SettingsApplied received - settings are now active');
-      log('SettingsApplied received - settings are now active');
-      // Only mark as sent when we get confirmation from Deepgram
+    // Handle SettingsApplied (Deepgram) or session.created (OpenAI proxy) - settings/session ready
+    // Issue #428: OpenAI proxy may send session.created as readiness signal; treat same as SettingsApplied
+    if (data.type === 'SettingsApplied' || data.type === 'session.created') {
+      const source = data.type === 'SettingsApplied' ? 'SettingsApplied' : 'session.created';
+      logger.info(`✅ [Protocol] ${source} received - settings are now active`);
+      log(`${source} received - settings are now active`);
       hasSentSettingsRef.current = true;
       windowWithGlobals.globalSettingsSent = true;
       dispatch({ type: 'SETTINGS_SENT', sent: true });
-      logConsole('debug','🎯 [SettingsApplied] Settings confirmed by agent, audio data can now be processed');
-      
-      // Call public API callback to notify that settings have been applied
+      logConsole('debug', `🎯 [${source}] Settings confirmed by agent, audio data can now be processed`);
+
       onSettingsApplied?.();
-      
+
       return;
     }
     

--- a/tests/on-settings-applied-callback.test.tsx
+++ b/tests/on-settings-applied-callback.test.tsx
@@ -26,6 +26,7 @@ import {
   createAgentOptions,
   setupComponentAndConnect,
   simulateSettingsApplied,
+  simulateSessionCreated,
   simulateConnection,
   setupConnectAndReceiveSettingsApplied,
   waitForEventListener,
@@ -75,6 +76,29 @@ describe('onSettingsApplied Callback Tests', () => {
       await setupConnectAndReceiveSettingsApplied(ref, mockWebSocketManager);
 
       // Verify callback was called
+      await waitFor(() => {
+        expect(onSettingsApplied).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('should call onSettingsApplied when session.created event is received (OpenAI proxy path)', async () => {
+      const onSettingsApplied = jest.fn();
+      const ref = React.createRef<DeepgramVoiceInteractionHandle>();
+
+      render(
+        <DeepgramVoiceInteraction
+          ref={ref}
+          apiKey={MOCK_API_KEY}
+          agentOptions={createMockAgentOptions()}
+          onSettingsApplied={onSettingsApplied}
+        />
+      );
+
+      const eventListener = await setupConnectAndReceiveSettingsApplied(ref, mockWebSocketManager);
+      onSettingsApplied.mockClear();
+
+      await simulateSessionCreated(eventListener);
+
       await waitFor(() => {
         expect(onSettingsApplied).toHaveBeenCalledTimes(1);
       });

--- a/tests/utils/component-test-helpers.tsx
+++ b/tests/utils/component-test-helpers.tsx
@@ -106,6 +106,26 @@ export async function simulateSettingsApplied(
 }
 
 /**
+ * Simulate receiving a session.created message (OpenAI proxy path).
+ * Issue #428: component should treat this as readiness and call onSettingsApplied.
+ */
+export async function simulateSessionCreated(
+  eventListener: ((event: any) => void) | undefined
+): Promise<void> {
+  if (eventListener) {
+    await act(async () => {
+      eventListener({
+        type: 'message',
+        data: {
+          type: 'session.created',
+          session: { id: 'sess-1', model: 'gpt-realtime', modalities: ['text', 'audio'] },
+        },
+      });
+    });
+  }
+}
+
+/**
  * Complete flow: Setup, connect, send Settings, and receive SettingsApplied
  * 
  * Note: setupComponentAndConnect already simulates SettingsApplied, so this function


### PR DESCRIPTION
## Summary
Fixes #428 — OpenAI proxy path now invokes `onSettingsApplied` when the backend sends `session.created`, so apps get a single readiness signal for both Deepgram (`SettingsApplied`) and OpenAI proxy (`session.created`).

## Changes
- **Component:** Treat `session.created` the same as `SettingsApplied` in message handling (same ref/state updates + `onSettingsApplied` callback).
- **Tests:** New unit test "should call onSettingsApplied when session.created event is received (OpenAI proxy path)" and `simulateSessionCreated()` helper.
- **Docs:** `docs/issues/ISSUE-428/README.md` and `RESOLUTION.md`.

## Verification
- `tests/on-settings-applied-callback.test.tsx` — 10/10 passed
- Related suites (voice-agent-api-validation, component-vad-callbacks, readiness-contract, etc.) — 63 tests passed
- No linter errors