### PR TITLE
fix(#508): Idle timeout must not fire between function result and chained function call

### DIFF
--- a/docs/issues/ISSUE-508/README.md
+++ b/docs/issues/ISSUE-508/README.md
@@ -1,0 +1,40 @@
+# Issue #508: Idle timeout fires before next agent turn when that turn is a function call (chained function calls)
+
+**GitHub:** [#508](https://github.com/Signal-Meaning/dg_react_agent/issues/508)  
+**Partner:** Voice-commerce ([#1058](https://github.com/Signal-Meaning/voice-commerce/issues/1058), AP2 mandate flow)  
+**Package:** @signal-meaning/voice-agent-react@0.10.0 (OpenAI proxy)  
+**Date reported:** 2026-03-08  
+**Status:** Open
+
+---
+
+## Summary
+
+When the app sends a function result, the next agent turn may be **another function call** (e.g. `create_cart_mandate` after `create_mandate`), not a text message. The component must **not** close the connection on idle while waiting for that next agent message. Currently, in a chained function-call flow, the idle timeout fires after the first function result and closes the connection before the model sends the next function call.
+
+**Expected:** Idle timeout is deactivated while the agent is active. Agent activity includes: (1) the model has requested a function call and we have not yet sent the result, and (2) we have sent a function result and the next agent message (text or **function call**) has not yet been received.
+
+**Actual:** After the first function result, "Idle timeout reached - closing agent connection" and WebSocket closes before the next function call in the chain (e.g. only `create_mandate` observed; `create_cart_mandate` and `execute_mandate` never received).
+
+---
+
+## Docs in this folder
+
+| Document | Purpose |
+|----------|---------|
+| [TDD-PLAN.md](./TDD-PLAN.md) | Test-driven development plan: Red → Green → Refactor for the fix. |
+
+## E2E coverage (partner scenario)
+
+**File:** `test-app/tests/e2e/issue-508-idle-timeout-chained-function-calls.spec.js`
+
+- Exercises the reported scenario: after first function result, next agent message is a (chained) function call; connection must stay open until that call is received.
+- Run from test-app with real API: `npm run test:e2e -- issue-508-idle-timeout-chained-function-calls.spec.js`
+
+---
+
+## References
+
+- Earlier idle-after–function-result behavior: fixed in v0.9.8 (Issue #487 / #373); this is the **reraise** for the **chained function call** case.
+- [IdleTimeoutService](../../../src/utils/IdleTimeoutService.ts): `waitingForNextAgentMessageAfterFunctionResult`, `FUNCTION_CALL_STARTED` / `FUNCTION_CALL_COMPLETED` / `AGENT_MESSAGE_RECEIVED` handling.
+- [ISSUE-489/IDLE-TIMEOUT-AFTER-FUNCTION-RESULT-DESIGN.md](../ISSUE-489/IDLE-TIMEOUT-AFTER-FUNCTION-RESULT-DESIGN.md) — design for clearing the waiting flag on agent message received.

--- a/docs/issues/ISSUE-508/TDD-PLAN.md
+++ b/docs/issues/ISSUE-508/TDD-PLAN.md
@@ -1,0 +1,142 @@
+# TDD Plan: Idle timeout must not fire between function result and next agent message when next message is a function call (Issue #508)
+
+**Goal:** Fix the component so the idle timeout does **not** fire after the app sends a function result while the next agent message (which may be another function call) has not yet been received. Chained function calls (e.g. create_mandate → create_cart_mandate → execute_mandate) must complete without the connection closing on idle.
+
+**Reference:** [README.md](./README.md) · **GitHub:** [#508](https://github.com/Signal-Meaning/dg_react_agent/issues/508)
+
+**Status: Implemented.** IdleTimeoutService now clears `waitingForNextAgentMessageAfterFunctionResult` and stops the max-wait timer when handling `FUNCTION_CALL_STARTED`, so the next agent message (including chained function calls) is treated as "agent message received" and the idle timeout does not start from the max-wait firing before the chained call is processed.
+
+---
+
+## Required contract (state machine)
+
+- After `FUNCTION_CALL_COMPLETED`, `waitingForNextAgentMessageAfterFunctionResult = true`.
+- It must be cleared on `AGENT_MESSAGE_RECEIVED` **or** on the next `FUNCTION_CALL_STARTED` (chained call).
+- `canStartTimeout` must be false while `waitingForNextAgentMessageAfterFunctionResult` or when `activeFunctionCalls.size > 0`.
+
+**Root cause:** The component today clears `waitingForNextAgentMessageAfterFunctionResult` only when it receives an agent message that triggers `onAgentMessageReceived` (e.g. ConversationText, AgentAudioDone). When the **next** agent message is a **function call**, that message may not be delivered in a way that calls `onAgentMessageReceived` before the idle timeout runs—or the component does not treat FUNCTION_CALL_STARTED as “next agent message received.” So we must **also** clear the waiting flag when a new function call starts (FUNCTION_CALL_STARTED).
+
+---
+
+## TDD workflow (mandatory)
+
+Follow **Red → Green → Refactor** for each change:
+
+1. **Red:** Add or extend a failing test that encodes the desired behavior.
+2. **Green:** Implement the minimal change so the test passes.
+3. **Refactor:** Clean up without changing behavior; keep tests green.
+
+---
+
+## Phase 1: Unit tests — IdleTimeoutService contract (RED then GREEN)
+
+### 1.1 Executable spec: FUNCTION_CALL_STARTED clears waitingForNextAgentMessageAfterFunctionResult
+
+**Red:**
+
+- Add a test (e.g. in `tests/agent-state-handling.test.ts` or a new `tests/idle-timeout-chained-function-calls-508.test.ts`) that encodes the partner’s state machine:
+  1. Apply: `FUNCTION_CALL_STARTED('create_mandate')` → `FUNCTION_CALL_COMPLETED('create_mandate')`.
+  2. Assert: `waitingForNextAgentMessageAfterFunctionResult === true` (or equivalent: `canStartTimeout()` is false when only this flag would block).
+  3. Apply: `FUNCTION_CALL_STARTED('create_cart_mandate')` (chained call).
+  4. Assert: `waitingForNextAgentMessageAfterFunctionResult === false` (cleared by the next function call).
+  5. Assert: `canStartTimeout()` is still false because `activeFunctionCalls.size > 0`.
+- If the service does not expose the flag directly, assert **behavior**: e.g. after step 2, advancing the idle timeout clock must **not** cause the timeout callback to fire before step 3; after step 3, timeout still must not fire while there is an active function call; after FUNCTION_CALL_COMPLETED for the last call and AGENT_MESSAGE_RECEIVED, timeout **can** start and fire.
+- Run tests → **RED** (current implementation does not clear the waiting flag on FUNCTION_CALL_STARTED, so either the assertion fails or the “timeout must not fire” assertion fails).
+
+**Green:**
+
+- In `IdleTimeoutService.handleEvent`, in the `FUNCTION_CALL_STARTED` branch: set `waitingForNextAgentMessageAfterFunctionResult = false`. Rationale: the next agent message has been received (it was a function call); we are no longer “waiting for next agent message after function result.”
+- Run tests → **GREEN**.
+
+**Refactor:**
+
+- Add a short comment in the service: e.g. “Issue #508: Clear waiting when next agent message is a function call (chained calls).”
+- Optionally add the partner’s full mandate-flow test (create_mandate → create_cart_mandate → execute_mandate → AGENT_MESSAGE_RECEIVED → canStartTimeout true).
+
+---
+
+### 1.2 Optional: Full mandate-flow sequence test
+
+**Red (optional):**
+
+- Test that after each `FUNCTION_CALL_COMPLETED` in the sequence [create_mandate, create_cart_mandate, execute_mandate], `canStartTimeout()` is false until the next `FUNCTION_CALL_STARTED` or `AGENT_MESSAGE_RECEIVED`.
+- After the final `AGENT_MESSAGE_RECEIVED`, `canStartTimeout()` is true (with other conditions idle).
+
+**Green:** Same implementation as 1.1; this test locks in the full chained-flow contract.
+
+---
+
+## Phase 2: Integration / E2E (partner-reported defect coverage)
+
+### 2.1 E2E: Chained function calls (added)
+
+**File:** `test-app/tests/e2e/issue-508-idle-timeout-chained-function-calls.spec.js`
+
+- Exercises the partner scenario: after the app sends the first function result, the next agent turn is another function call (`chained_step_one` → `chained_step_two`).
+- Uses proxy mode + real API; `setupFunctionCallingTest` with two functions; user message "Run both steps: do step one then step two."
+- **Assert:** `functionCallRequests` contains both calls in order; connection did not close with "Idle timeout reached" before the second call.
+- Run from test-app: `npm run test:e2e -- issue-508-idle-timeout-chained-function-calls.spec.js` (with real API and backend).
+
+### 2.2 Protocol-level repro (Option A from defect report)
+
+- Connect with `idle_timeout` = 10000 ms and a function the model can call.
+- User/test sends a message that causes the model to call that function.
+- App sends the function result; **do not** send any further messages from the model (simulate “next message will be a function call but has not arrived yet”).
+- Wait up to `idle_timeout` seconds.
+- **Assert:** Connection is still open; component does **not** close with “Idle timeout reached - closing agent connection.”
+
+This can be implemented as an E2E test in test-app (e.g. in `test-app/tests/e2e/idle-timeout-behavior.spec.js` or a dedicated spec for issue-508) using a mock that never sends the next function call, or as an integration test that drives the component with the same event sequence and asserts the idle timeout callback is not invoked in the waiting window.
+
+### 2.3 Full mandate flow (voice-commerce)
+
+- When voice-commerce runs the full mandate flow with real API, their E2E that asserts `create_mandate` → `create_cart_mandate` → `execute_mandate` in order should pass once the component fix is in place (connection stays open until the full chain completes or agent sends text).
+
+---
+
+## Phase 3: Summary of changes
+
+| Step | Type | Action |
+|------|------|--------|
+| 1 | Unit test | Add test(s) that after FUNCTION_CALL_COMPLETED, waiting is true; after FUNCTION_CALL_STARTED (chained), waiting is false; timeout does not fire in the gap. |
+| 2 | IdleTimeoutService | In FUNCTION_CALL_STARTED handler, set `waitingForNextAgentMessageAfterFunctionResult = false`. |
+| 3 | Refactor | Comment in service; optional full mandate-flow unit test. |
+| 4 | E2E | Added `issue-508-idle-timeout-chained-function-calls.spec.js`: chained function-call flow; assert both calls received in order and connection did not close on idle before second call. |
+
+---
+
+## Copy-paste: Partner’s executable spec (for reference)
+
+The partner provided a Jest-style state machine and two tests. These can be added to our suite as an executable specification of the contract (see GitHub issue #508 body). The component fix (clear waiting on FUNCTION_CALL_STARTED) satisfies this spec.
+
+```javascript
+// Events: MEANINGFUL_USER_ACTIVITY | FUNCTION_CALL_STARTED | FUNCTION_CALL_COMPLETED | AGENT_MESSAGE_RECEIVED
+// Required: after FUNCTION_CALL_COMPLETED, waitingForNextAgentMessageAfterFunctionResult = true.
+// Cleared on AGENT_MESSAGE_RECEIVED OR on next FUNCTION_CALL_STARTED (chained call).
+// canStartTimeout must be false while waitingForNextAgentMessageAfterFunctionResult or activeFunctionCalls.size > 0.
+
+function applyContract(event, state) {
+  switch (event.type) {
+    case 'FUNCTION_CALL_STARTED':
+      state.activeFunctionCalls.add(event.functionCallId);
+      state.waitingForNextAgentMessageAfterFunctionResult = false; // next agent message can be a function call
+      break;
+    case 'FUNCTION_CALL_COMPLETED':
+      state.activeFunctionCalls.delete(event.functionCallId);
+      if (state.activeFunctionCalls.size === 0) state.waitingForNextAgentMessageAfterFunctionResult = true;
+      break;
+    case 'AGENT_MESSAGE_RECEIVED':
+      state.waitingForNextAgentMessageAfterFunctionResult = false;
+      break;
+    // ...
+  }
+}
+```
+
+---
+
+## References
+
+- [IdleTimeoutService](../../../src/utils/IdleTimeoutService.ts) — `FUNCTION_CALL_STARTED` / `FUNCTION_CALL_COMPLETED` / `AGENT_MESSAGE_RECEIVED` handling; `canStartTimeout`, `waitingForNextAgentMessageAfterFunctionResult`.
+- [useIdleTimeoutManager](../../../src/hooks/useIdleTimeoutManager.ts) — `handleFunctionCallStarted`, `handleFunctionCallCompleted`, `notifyAgentMessageReceived`.
+- [ISSUE-489 TDD-PLAN-IDLE-TIMEOUT-AFTER-FUNCTION-CALL.md](../ISSUE-489/TDD-PLAN-IDLE-TIMEOUT-AFTER-FUNCTION-CALL.md) — previous fix for “waiting for next message after function result” (single function + text).
+- Partner defect report (voice-commerce #1058): summary, Option A repro, executable protocol spec, suggested component fix.

--- a/src/utils/IdleTimeoutService.ts
+++ b/src/utils/IdleTimeoutService.ts
@@ -284,6 +284,10 @@ export class IdleTimeoutService {
         // Issue #373: Function calls are active operations - disable idle timeout during execution
         this.activeFunctionCalls.add(event.functionCallId);
         this.log(`FUNCTION_CALL_STARTED: ${event.functionCallId} (active calls: ${this.activeFunctionCalls.size})`);
+        // Issue #508: Next agent message can be a function call (chained). Clear waiting and cancel max-wait
+        // so we do not start the idle timeout when max-wait fires; treat "next message received" here.
+        this.waitingForNextAgentMessageAfterFunctionResult = false;
+        this.stopMaxWaitForAgentReplyTimer();
         // Disable idle timeout resets when any function call is active
         // This prevents timeout from firing during function execution
         this.disableResets();

--- a/test-app/tests/e2e/issue-508-idle-timeout-chained-function-calls.spec.js
+++ b/test-app/tests/e2e/issue-508-idle-timeout-chained-function-calls.spec.js
@@ -1,0 +1,142 @@
+/**
+ * Issue #508: Idle timeout must NOT fire between function result and next agent message when that message is a function call (chained)
+ *
+ * Partner report (voice-commerce #1058): In a chained function-call flow (e.g. create_mandate → create_cart_mandate → execute_mandate),
+ * the idle timeout was firing after the first function result and closing the connection before the model sent the next function call.
+ *
+ * This E2E exercises the reported scenario: after the app sends a function result, the next agent turn is another function call.
+ * The component must keep the connection open until that second call is received (no "Idle timeout reached" in between).
+ *
+ * Requirements:
+ * - Proxy mode with real API (OpenAI or Deepgram). E2E_BACKEND=openai (default) or deepgram.
+ * - Real API key; backend running (e.g. cd test-app && npm run backend).
+ *
+ * Run from test-app:
+ *   npm run test:e2e -- issue-508-idle-timeout-chained-function-calls.spec.js
+ * With real API and existing server:
+ *   E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true USE_REAL_APIS=1 npm run test:e2e -- issue-508-idle-timeout-chained-function-calls.spec.js
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  skipIfNoRealAPI,
+  waitForConnection,
+  waitForSettingsApplied,
+  setupFunctionCallingTest,
+} from './helpers/test-helpers.js';
+import { pathWithQuery, getBackendProxyParams } from './helpers/test-helpers.mjs';
+
+const IS_PROXY_MODE = process.env.USE_PROXY_MODE !== 'false';
+
+/** Chained flow function names (order matters for assertion). */
+const CHAINED_FIRST = 'chained_step_one';
+const CHAINED_SECOND = 'chained_step_two';
+
+const chainedFunctions = [
+  {
+    name: CHAINED_FIRST,
+    description: 'First step of a two-step chained flow. You must call this first, then call ' + CHAINED_SECOND + '. Use when the user asks to run both steps or do step one then step two.',
+    parameters: { type: 'object', properties: {} },
+  },
+  {
+    name: CHAINED_SECOND,
+    description: 'Second step of the chained flow. Call this after calling ' + CHAINED_FIRST + '. Use when the user asked to run both steps or after you have called ' + CHAINED_FIRST + '.',
+    parameters: { type: 'object', properties: {} },
+  },
+];
+
+test.describe('Issue #508: Idle timeout with chained function calls', () => {
+  test.beforeEach(async ({ page, context }) => {
+    skipIfNoRealAPI('Requires real API for chained function-call E2E');
+    await context.grantPermissions(['microphone']);
+    await page.addInitScript(() => {
+      window.__DEEPGRAM_TEST_MODE__ = true;
+    });
+    if (!IS_PROXY_MODE) {
+      console.warn('⚠️  USE_PROXY_MODE is false - this test requires proxy mode');
+    }
+  });
+
+  test.afterEach(async ({ page }) => {
+    try {
+      await page.evaluate(() => {
+        if (window.deepgramRef?.current) window.deepgramRef.current.stop?.();
+      });
+      await page.goto('about:blank');
+      await page.waitForTimeout(500);
+    } catch (_) {}
+  });
+
+  /**
+   * Partner scenario (voice-commerce #1058): After first function result, next agent message is another function call.
+   * Connection must stay open until the second call is received (no idle timeout in between).
+   */
+  test('connection stays open between first function result and second (chained) function call', async ({ page }) => {
+    test.setTimeout(90000);
+
+    const idleTimeoutLogs = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (text.includes('Idle timeout reached') || text.includes('closing agent connection')) {
+        idleTimeoutLogs.push({ time: Date.now(), text });
+      }
+    });
+
+    await setupFunctionCallingTest(page, {
+      functions: chainedFunctions,
+      handler: (functionName) =>
+        functionName === CHAINED_FIRST ? { step: 1, id: 'step-one' } : { step: 2, id: 'step-two' },
+    });
+
+    const testUrl = pathWithQuery({
+      ...getBackendProxyParams(),
+      'enable-function-calling': 'true',
+      'test-mode': 'true',
+      debug: 'true',
+    });
+    await page.goto(testUrl);
+    await page.waitForSelector('[data-testid="voice-agent"]', { timeout: 10000 });
+
+    const textInput = page.locator('[data-testid="text-input"]');
+    await textInput.waitFor({ state: 'visible', timeout: 10000 });
+    await textInput.focus();
+    await page.waitForSelector('[data-testid="connection-status"]', { timeout: 10000 });
+    await waitForConnection(page, 30000);
+    await waitForSettingsApplied(page, 10000);
+
+    await page.evaluate(() => {
+      const ref = window.deepgramRef || window.voiceAgentRef;
+      if (ref?.current) ref.current.injectUserMessage('Run both steps: do step one then step two.');
+    });
+
+    const deadline = Date.now() + 45000;
+    let names = [];
+    while (Date.now() < deadline) {
+      names = await page.evaluate(() => (window.functionCallRequests || []).map((r) => r.name || r.function?.name).filter(Boolean));
+      if (names.length >= 2 && names[0] === CHAINED_FIRST && names[1] === CHAINED_SECOND) break;
+      await page.waitForTimeout(500);
+    }
+
+    const connectionStatus = await page.evaluate(() => {
+      const el = document.querySelector('[data-testid="connection-status"]');
+      return el?.textContent?.toLowerCase() || '';
+    });
+
+    if (names.length < 2) {
+      console.log('[Issue #508] Function calls received (order):', names);
+      console.log('[Issue #508] Idle timeout logs:', idleTimeoutLogs.length ? idleTimeoutLogs : 'none');
+    }
+
+    expect(
+      names.length >= 2 && names[0] === CHAINED_FIRST && names[1] === CHAINED_SECOND,
+      'Chained flow should receive ' + CHAINED_FIRST + ' then ' + CHAINED_SECOND + '. Got: [' + names.join(', ') + ']. ' +
+        'Connection status: ' + connectionStatus + '. ' +
+        (idleTimeoutLogs.length ? 'Idle timeout fired: ' + idleTimeoutLogs.map((l) => l.text).join('; ') : '')
+    ).toBe(true);
+
+    expect(
+      idleTimeoutLogs.length === 0 || names.length >= 2,
+      'Connection must not close due to idle timeout before the second (chained) function call is received.'
+    ).toBe(true);
+  });
+});

--- a/tests/integration/unified-timeout-coordination.test.js
+++ b/tests/integration/unified-timeout-coordination.test.js
@@ -406,6 +406,76 @@ describe('Unified Timeout Coordination Integration', () => {
     });
 
     /**
+     * Issue #508 (voice-commerce #1058): When the next agent message after a function result is
+     * another FUNCTION_CALL_STARTED (chained call), the component must clear
+     * waitingForNextAgentMessageAfterFunctionResult and stop the max-wait timer so the idle
+     * timeout does not fire. Simulates: no AGENT_MESSAGE_RECEIVED for the function-call message
+     * (only FUNCTION_CALL_STARTED when the app processes it); without the fix, max-wait fires
+     * at 500ms and we start the timeout, which fires at 5.5s.
+     */
+    test('Issue #508: should NOT timeout when next agent message is a chained function call (FUNCTION_CALL_STARTED clears waiting)', () => {
+      const timeoutMs = 5000;
+      // 1. Establish session with user activity and idle state
+      idleTimeoutService.handleEvent({ type: 'MEANINGFUL_USER_ACTIVITY', activity: 'session' });
+      idleTimeoutService.handleEvent({ type: 'USER_STOPPED_SPEAKING' });
+      idleTimeoutService.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });
+
+      // 2. First function call: create_mandate
+      idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_STARTED', functionCallId: 'create_mandate' });
+      idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_COMPLETED', functionCallId: 'create_mandate' });
+
+      // 3. Before default max-wait (500ms) fires, next agent message arrives as a function call (chained).
+      //    Simulate that only FUNCTION_CALL_STARTED is sent to idle service (no AGENT_MESSAGE_RECEIVED for function-call messages).
+      jest.advanceTimersByTime(400);
+      idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_STARTED', functionCallId: 'create_cart_mandate' });
+
+      // 4. Wait past when timeout would have fired without the fix (max-wait 500ms + timeout 5s = 5.5s)
+      jest.advanceTimersByTime(6000);
+
+      // 5. ASSERT: connection must still be open (timeout must NOT have fired)
+      expect(mockOnTimeout).not.toHaveBeenCalled();
+
+      // 6. Complete the chained flow; then next agent message (text) received
+      idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_COMPLETED', functionCallId: 'create_cart_mandate' });
+      idleTimeoutService.handleEvent({ type: 'AGENT_MESSAGE_RECEIVED' });
+
+      // 7. Now timeout may start and fire after idle period
+      jest.advanceTimersByTime(timeoutMs);
+      expect(mockOnTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    /**
+     * Issue #508: Full mandate flow — after each FUNCTION_CALL_COMPLETED, canStartTimeout must be false
+     * until the next FUNCTION_CALL_STARTED or AGENT_MESSAGE_RECEIVED. Verifies the contract for chained calls.
+     */
+    test('Issue #508: mandate flow (create_mandate → create_cart_mandate → execute_mandate) — no timeout between function result and next function call', () => {
+      const timeoutMs = 5000;
+      const MANDATE_FLOW_NAMES = ['create_mandate', 'create_cart_mandate', 'execute_mandate'];
+
+      idleTimeoutService.handleEvent({ type: 'MEANINGFUL_USER_ACTIVITY', activity: 'session' });
+      idleTimeoutService.handleEvent({ type: 'USER_STOPPED_SPEAKING' });
+      idleTimeoutService.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });
+
+      // Chained function calls: each COMPLETED leaves us waiting; each next STARTED clears waiting
+      for (let i = 0; i < MANDATE_FLOW_NAMES.length; i++) {
+        const name = MANDATE_FLOW_NAMES[i];
+        idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_STARTED', functionCallId: name });
+        idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_COMPLETED', functionCallId: name });
+        // Wait past max-wait (500ms) — timeout must NOT have fired (we're either waiting or will get next STARTED)
+        jest.advanceTimersByTime(600);
+        expect(mockOnTimeout).not.toHaveBeenCalled();
+        // Next agent message is the next function call (or after last, we send AGENT_MESSAGE_RECEIVED below)
+        if (i + 1 < MANDATE_FLOW_NAMES.length) {
+          idleTimeoutService.handleEvent({ type: 'FUNCTION_CALL_STARTED', functionCallId: MANDATE_FLOW_NAMES[i + 1] });
+        }
+      }
+
+      idleTimeoutService.handleEvent({ type: 'AGENT_MESSAGE_RECEIVED' });
+      jest.advanceTimersByTime(timeoutMs);
+      expect(mockOnTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    /**
      * Issue #487 (voice-commerce #1058): Idle timeout must NOT fire while waiting for next
      * agent message after the app has sent a function result. The agent is still busy
      * (model has not yet sent the next function call or final response).


### PR DESCRIPTION
## Summary

Fixes #508 (voice-commerce #1058): In chained function-call flows (e.g. create_mandate → create_cart_mandate → execute_mandate), the idle timeout was firing after the first function result and closing the connection before the model sent the next function call.

## Changes

- **IdleTimeoutService:** On `FUNCTION_CALL_STARTED`, clear `waitingForNextAgentMessageAfterFunctionResult` and stop the max-wait timer so the next agent message (when it is a function call) is treated as received; connection no longer closes on idle in that window.
- **Unit tests:** Issue #508 tests in `unified-timeout-coordination.test.js` (chained call clears waiting; mandate-flow sequence).
- **E2E:** `test-app/tests/e2e/issue-508-idle-timeout-chained-function-calls.spec.js` exercises the partner scenario (two-step chained flow; connection stays open).
- **Docs:** `docs/issues/ISSUE-508/` (README, TDD-PLAN).

## Verification

- `npm test -- tests/integration/unified-timeout-coordination.test.js` — 29 passed
- E2E (from test-app): `npm run test:e2e -- issue-508-idle-timeout-chained-function-calls.spec.js` — 1 passed

Made with [Cursor](https://cursor.com)