### PR TITLE
fix: customer idle timeout vs playback + proxy AgentAudioDone ordering (#527)

### DIFF
--- a/packages/voice-agent-backend/scripts/openai-proxy/server.ts
+++ b/packages/voice-agent-backend/scripts/openai-proxy/server.ts
@@ -189,11 +189,15 @@ export function createOpenAIProxyServer(options: OpenAIProxyServerOptions): {
     let lastTtsChunk: Buffer | null = null;
     const ttsBoundaryDebug = process.env.OPENAI_PROXY_TTS_BOUNDARY_DEBUG === '1';
 
+    /** Voice-commerce #1118: For TTS turns, API may send output_text.done before output_audio.done. We must not send AgentAudioDone on output_text.done when this response has audio, or idle timer starts while playback continues. */
+    let hasReceivedOutputAudioDeltaForCurrentResponse = false;
+
     /** Issue #482: Response lifecycle helpers so agent-activity and idle_timeout buffering stay DRY. */
     const onResponseStarted = (): void => {
       responseInProgress = true;
       hasSentAgentStartedSpeakingForCurrentResponse = false;
       hasSentAgentAudioDoneForCurrentResponse = false;
+      hasReceivedOutputAudioDeltaForCurrentResponse = false;
     };
 
     /** Issue #522: Send deferred response.create after function_call_output (REQUIRED-UPSTREAM-CONTRACT.md). Clears timeout, resets flag, sends response.create, calls onResponseStarted. Call only when pendingResponseCreateAfterFunctionCallOutput is true. */
@@ -619,7 +623,11 @@ export function createOpenAIProxyServer(options: OpenAIProxyServerOptions): {
             attributes: { ...connectionAttrs, [ATTR_DIRECTION]: 'upstream→client', [ATTR_MESSAGE_TYPE]: msg.type },
           });
           sendAgentStartedSpeakingIfNeeded();
-          sendAgentAudioDoneIfNeeded();
+          // Voice-commerce #1118: text may finish before audio; if we already streamed PCM, defer
+          // AgentAudioDone to response.output_audio.done so the client idle timer does not start early.
+          if (!hasReceivedOutputAudioDeltaForCurrentResponse) {
+            sendAgentAudioDoneIfNeeded();
+          }
           flushPendingIdleTimeoutError();
         } else if (msg.type === 'response.output_audio_transcript.done') {
           emitLog({
@@ -747,6 +755,7 @@ export function createOpenAIProxyServer(options: OpenAIProxyServerOptions): {
           if (delta && typeof delta === 'string') {
             const pcm = Buffer.from(delta, 'base64');
             if (pcm.length > 0) {
+              hasReceivedOutputAudioDeltaForCurrentResponse = true; // Voice-commerce #1118: defer AgentAudioDone from output_text.done until output_audio.done
               sendAgentStartedSpeakingIfNeeded();
               if (ttsBoundaryDebug && lastTtsChunk !== null) {
                 const bufA = lastTtsChunk;

--- a/src/components/DeepgramVoiceInteraction/index.tsx
+++ b/src/components/DeepgramVoiceInteraction/index.tsx
@@ -2482,38 +2482,48 @@ function DeepgramVoiceInteraction(
     }
     
     // Agent done for the turn: accept either AgentDone (semantic) or AgentAudioDone (legacy receipt-complete).
-    // AgentDone = proxy signals "agent is done" (prefer when supported). AgentAudioDone = receipt complete only, not playback.
+    // Wire receipt is NOT playback complete: do not force isPlaying false or agent idle while AudioManager still has active playback.
     if (data.type === 'AgentDone' || data.type === 'AgentAudioDone') {
       const eventType = data.type as 'AgentDone' | 'AgentAudioDone';
       logConsole('debug', `🔊 [AGENT EVENT] ${eventType} received`);
-      logConsole('debug', `🎯 [AGENT] ${eventType} - agent done for turn (semantic); transitioning to idle`);
-      sleepLog(`${eventType} received - agent done for turn`);
+      logConsole('debug', `🎯 [AGENT] ${eventType} - agent turn output receipt complete (playback may continue)`);
+      sleepLog(`${eventType} received - agent turn receipt complete`);
 
-      // Transition to idle when in speaking, listening, or thinking so idle timeout can start.
-      // IdleTimeoutService requires isPlaying: false and agentState idle/listening to start the timeout.
+      const agentState = stateRef.current.agentState;
+      const playbackStillActive = audioManagerRef.current?.isPlaybackActive?.() === true;
+
       // Issue #489: In function-call flow we may receive AgentAudioDone while still in 'thinking' (no audio
       // for that turn); if we don't transition to idle here, the service never starts the idle timeout.
-      const agentState = stateRef.current.agentState;
-      if (agentState === 'speaking') {
-        logConsole('debug','🎯 [AGENT] Agent done - transitioning to idle (response complete)');
+      if (agentState === 'speaking' && playbackStillActive) {
+        logConsole(
+          'debug',
+          '🎯 [AGENT] Agent receipt done while TTS still playing — deferring idle/playback until AudioManager finishes'
+        );
+        handleMeaningfulActivity(eventType);
+      } else if (agentState === 'speaking') {
+        logConsole('debug','🎯 [AGENT] Agent done - transitioning to idle (response complete, no active playback)');
         agentStateServiceRef.current?.handleAudioPlaybackChange(false);
         dispatch({ type: 'PLAYBACK_STATE_CHANGE', isPlaying: false });
         dispatch({ type: 'AGENT_STATE_CHANGE', state: 'idle' });
+        pushIdleStateToIdleTimeoutService();
+        handleMeaningfulActivity(eventType);
       } else if (agentState === 'listening') {
         logConsole('debug','🎯 [AGENT] Agent done while listening - transitioning to idle (greeting/response done before playback)');
         dispatch({ type: 'PLAYBACK_STATE_CHANGE', isPlaying: false });
         dispatch({ type: 'AGENT_STATE_CHANGE', state: 'idle' });
+        pushIdleStateToIdleTimeoutService();
+        handleMeaningfulActivity(eventType);
       } else if (agentState === 'thinking') {
         logConsole('debug','🎯 [AGENT] Agent done while thinking - transitioning to idle (e.g. text-only turn after function call)');
         dispatch({ type: 'PLAYBACK_STATE_CHANGE', isPlaying: false });
         dispatch({ type: 'AGENT_STATE_CHANGE', state: 'idle' });
+        pushIdleStateToIdleTimeoutService();
+        handleMeaningfulActivity(eventType);
+      } else {
+        // Already idle (or unexpected); still sync idle timeout service and meaningful activity for #489 paths
+        pushIdleStateToIdleTimeoutService();
+        handleMeaningfulActivity(eventType);
       }
-
-      // Issue #489: Always push idle into the service so it can start the timeout (React state updates
-      // are async). If we only push when agentState is speaking/listening/thinking, then when
-      // agentState is already 'idle' the service may keep stale state (e.g. 'thinking') and never start.
-      pushIdleStateToIdleTimeoutService();
-      handleMeaningfulActivity(eventType);
 
       // TODO(issue-489): Remove before concluding Issue #489 — E2E flag to confirm proxy → component AgentAudioDone delivery.
       if (typeof window !== 'undefined') {
@@ -3777,6 +3787,8 @@ function DeepgramVoiceInteraction(
             
             // Also dispatch directly as fallback (redundant but safe)
             dispatch({ type: 'AGENT_STATE_CHANGE', state: 'idle' });
+            // After deferred AgentAudioDone (receipt before playback end), service may need explicit sync before hook effects run
+            pushIdleStateToIdleTimeoutService();
           } else {
             logConsole('debug',`🎯 [AGENT] Audio playback stopped but agent state is ${currentState} (not speaking) - skipping transition to idle`);
           }

--- a/src/hooks/useIdleTimeoutManager.ts
+++ b/src/hooks/useIdleTimeoutManager.ts
@@ -1,14 +1,27 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { DEFAULT_IDLE_TIMEOUT_MS } from '../constants/voice-agent';
 import { VoiceInteractionState } from '../utils/state/VoiceInteractionState';
 import { WebSocketManager } from '../utils/websocket/WebSocketManager';
-import { IdleTimeoutService, IdleTimeoutEvent } from '../utils/IdleTimeoutService';
+import { IdleTimeoutService, type IdleTimeoutInteractionSnapshot } from '../utils/IdleTimeoutService';
 import { getLogger } from '../utils/logger';
 
+function interactionSnapshot(state: VoiceInteractionState): IdleTimeoutInteractionSnapshot {
+  return {
+    agentState: state.agentState,
+    isPlaying: state.isPlaying,
+    isUserSpeaking: state.isUserSpeaking,
+  };
+}
+
 /**
- * Custom hook for managing idle timeout using the IdleTimeoutService.
- * Uses the shared DEFAULT_IDLE_TIMEOUT_MS (or timeoutMs override) so the same
- * value can be used in Settings for the OpenAI proxy.
+ * Idle disconnect timer via `IdleTimeoutService`.
+ *
+ * **React interaction state** (`agentState`, `isPlaying`, `isUserSpeaking`) is pushed through a single
+ * API — `applyCommittedInteractionState` — from `useLayoutEffect` after commit, so the service does not
+ * rely on `useEffect` ordering relative to paint or other effects.
+ *
+ * **Other signals** (UtteranceEnd, tool/function lifecycle, WS meaningful activity, `pushIdleStateToIdleTimeoutService`)
+ * still call `handleEvent` / `updateStateDirectly` directly; they are not duplicated in the layout snapshot.
  */
 export function useIdleTimeoutManager(
   state: VoiceInteractionState,
@@ -29,10 +42,8 @@ export function useIdleTimeoutManager(
     callbackRef.current = onIdleTimeoutActiveChange;
   }, [onIdleTimeoutActiveChange]);
 
-  // Initialize the service
-  useEffect(() => {
-    // Issue #235: Destroy any existing service BEFORE creating a new one
-    // This prevents multiple timeout handlers from existing simultaneously
+  // Create / destroy service in layout phase so it exists before the committed-state sync below (same tick).
+  useLayoutEffect(() => {
     if (serviceRef.current) {
       logger.debug('Destroying existing IdleTimeoutService before creating new one');
       serviceRef.current.destroy();
@@ -44,32 +55,26 @@ export function useIdleTimeoutManager(
       timeoutMs,
       debug,
     });
-    logger.debug('IdleTimeoutService created successfully');
 
     serviceRef.current.onTimeout(() => {
       logger.info('Idle timeout reached - closing agent connection');
-      // E2E diagnostic (Issue #489): expose so tests can assert timeout fired even if close not yet reflected in UI
       if (typeof window !== 'undefined') {
         (window as unknown as { __idleTimeoutFired__?: boolean }).__idleTimeoutFired__ = true;
       }
       agentManagerRef.current?.close();
     });
 
-    // Set up callback to expose idle timeout active state changes
-    // Use ref to access latest callback without recreating service when callback changes
     prevTimeoutActiveRef.current = false;
     serviceRef.current.onStateChange(() => {
       const currentTimeoutActive = serviceRef.current?.isTimeoutActive() ?? false;
       if (currentTimeoutActive !== prevTimeoutActiveRef.current) {
         prevTimeoutActiveRef.current = currentTimeoutActive;
-        // Use ref to get latest callback, avoiding stale closures
         callbackRef.current?.(currentTimeoutActive);
       }
     });
 
     return () => {
       logger.debug('Destroying IdleTimeoutService (cleanup)');
-      // Issue #235: Ensure service is destroyed and timeout is cancelled
       if (serviceRef.current) {
         serviceRef.current.destroy();
         serviceRef.current = null;
@@ -77,88 +82,32 @@ export function useIdleTimeoutManager(
     };
   }, [debug, timeoutMs]);
 
-  // Set up state getter once (reads from ref to always get latest state)
-  useEffect(() => {
-    if (serviceRef.current) {
-      // Set up state getter for polling to read state directly from component
-      // Use ref to ensure we always read the latest state, not a captured value
-      serviceRef.current.setStateGetter(() => {
-        return {
-          agentState: currentStateRef.current.agentState,
-          isPlaying: currentStateRef.current.isPlaying,
-          isUserSpeaking: currentStateRef.current.isUserSpeaking,
-        };
-      });
-    }
-  }, []); // Only set once - reads from ref which is always current
-
-  // Handle state changes
+  // After service exists; re-attach when service instance is recreated (timeoutMs / debug).
   useEffect(() => {
     if (!serviceRef.current) return;
+    serviceRef.current.setStateGetter(() => ({
+      agentState: currentStateRef.current.agentState,
+      isPlaying: currentStateRef.current.isPlaying,
+      isUserSpeaking: currentStateRef.current.isUserSpeaking,
+    }));
+  }, [debug, timeoutMs]);
 
-    // Keep stateGetter's ref in sync so IdleTimeoutService sees latest state (fixes greeting idle timeout E2E)
+  // Single post-commit path: after React applies state, push one snapshot into IdleTimeoutService
+  // (merge + semantic transitions) before paint. Avoids useEffect ordering vs idle countdown.
+  useLayoutEffect(() => {
+    if (!serviceRef.current) return;
+
     currentStateRef.current = state;
 
-    const currentState = {
-      isUserSpeaking: state.isUserSpeaking,
-      agentState: state.agentState,
-      isPlaying: state.isPlaying,
-    };
+    const prevSnapshot = interactionSnapshot(prevStateRef.current);
+    const nextSnapshot = interactionSnapshot(state);
 
-    const prevState = {
-      isUserSpeaking: prevStateRef.current.isUserSpeaking,
-      agentState: prevStateRef.current.agentState,
-      isPlaying: prevStateRef.current.isPlaying,
-    };
-
-    // Issue #489: Sync full state to the service BEFORE emitting transition events.
-    // Otherwise the first event (e.g. AGENT_STATE_CHANGED) runs updateTimeoutBehavior() while
-    // the service still has stale isPlaying/agentState from the previous render, so we
-    // incorrectly call disableResets() and stop a timeout we just started.
-    const stateChanged =
-      currentState.agentState !== prevState.agentState ||
-      currentState.isPlaying !== prevState.isPlaying ||
-      currentState.isUserSpeaking !== prevState.isUserSpeaking;
-    if (stateChanged) {
-      serviceRef.current.updateStateDirectly({
-        agentState: currentState.agentState,
-        isPlaying: currentState.isPlaying,
-        isUserSpeaking: currentState.isUserSpeaking,
-      });
-    }
-
-    logger.debug('State change detected', {
-      prev: prevState,
-      current: currentState,
-      agentStateChanged: currentState.agentState !== prevState.agentState,
-      isPlayingChanged: currentState.isPlaying !== prevState.isPlaying,
-      isUserSpeakingChanged: currentState.isUserSpeaking !== prevState.isUserSpeaking
+    logger.debug('Committed interaction snapshot → IdleTimeoutService', {
+      prev: prevSnapshot,
+      next: nextSnapshot,
     });
 
-    // Emit events for state changes
-    if (currentState.isUserSpeaking !== prevState.isUserSpeaking) {
-      const event: IdleTimeoutEvent = currentState.isUserSpeaking 
-        ? { type: 'USER_STARTED_SPEAKING' }
-        : { type: 'USER_STOPPED_SPEAKING' };
-      logger.debug('Emitting USER_STARTED/STOPPED_SPEAKING event');
-      serviceRef.current.handleEvent(event);
-    }
-
-    if (currentState.agentState !== prevState.agentState) {
-      logger.debug(`Emitting AGENT_STATE_CHANGED: ${prevState.agentState} -> ${currentState.agentState}`);
-      serviceRef.current.handleEvent({ 
-        type: 'AGENT_STATE_CHANGED', 
-        state: currentState.agentState 
-      });
-    }
-
-    if (currentState.isPlaying !== prevState.isPlaying) {
-      logger.debug(`Emitting PLAYBACK_STATE_CHANGED: ${prevState.isPlaying} -> ${currentState.isPlaying}`);
-      serviceRef.current.handleEvent({ 
-        type: 'PLAYBACK_STATE_CHANGED', 
-        isPlaying: currentState.isPlaying 
-      });
-    }
+    serviceRef.current.applyCommittedInteractionState(prevSnapshot, nextSnapshot);
 
     prevStateRef.current = state;
   }, [state.isUserSpeaking, state.agentState, state.isPlaying, debug]);
@@ -223,11 +172,14 @@ export function useIdleTimeoutManager(
    */
   const pushIdleStateToIdleTimeoutService = useCallback(() => {
     if (serviceRef.current) {
-      serviceRef.current.updateStateDirectly({
-        agentState: 'idle',
-        isPlaying: false,
-        isUserSpeaking: false,
-      });
+      serviceRef.current.updateStateDirectly(
+        {
+          agentState: 'idle',
+          isPlaying: false,
+          isUserSpeaking: false,
+        },
+        { source: 'react-commit' }
+      );
     }
   }, []);
 

--- a/src/utils/IdleTimeoutService.ts
+++ b/src/utils/IdleTimeoutService.ts
@@ -23,6 +23,21 @@ export interface IdleTimeoutState {
   isPlaying: boolean;
 }
 
+/** Subset of {@link IdleTimeoutState} synced from React after commit (`applyCommittedInteractionState`). */
+export type IdleTimeoutInteractionSnapshot = Pick<
+  IdleTimeoutState,
+  'agentState' | 'isPlaying' | 'isUserSpeaking'
+>;
+
+/** Options for {@link IdleTimeoutService.updateStateDirectly}. */
+export type UpdateStateDirectlyOptions = {
+  /**
+   * `react-commit`: state comes from `useLayoutEffect` after React applied the tree — merge immediately
+   * (do not defer "busy" merges). Used by {@link IdleTimeoutService.applyCommittedInteractionState}.
+   */
+  source?: 'default' | 'react-commit';
+};
+
 export type IdleTimeoutEvent = 
   | { type: 'USER_STARTED_SPEAKING' }
   | { type: 'USER_STOPPED_SPEAKING' }
@@ -49,19 +64,22 @@ export class IdleTimeoutService {
   // Issue #373: Track active function calls to prevent idle timeout during execution
   private activeFunctionCalls: Set<string> = new Set();
   /**
-   * Issue #487: After the app sends a function result, we block the idle timer until we have
-   * a signal that the agent has become active (so we're not closing before the reply). Cleared when:
-   * (1) AGENT_STATE_CHANGED to 'thinking' or 'speaking' — agent became active (primary).
-   * (2) AGENT_MESSAGE_RECEIVED — invoked only by WebSocketManager when it emits a message (single path).
-   * (3) Max-wait fallback (capped at timeoutMs) — if backend sends no signal, we allow the
-   *     idle timer to start after at most one idle-timeout period so the connection can close.
+   * After the app sends a **tool/function result** to the model, there is often a **silent window** where
+   * the UI still looks idle but the assistant is actually working on the follow-up. We must not start the
+   * "disconnect if inactive" timer in that window, or we would hang up before the user hears the answer.
+   *
+   * This flag is **not** the product rule by itself — it is a latch for that window. We clear it when we
+   * see **real assistant activity** (same idea as "thinking / forming a result"), via:
+   * - `AGENT_STATE_CHANGED` → `thinking` or `speaking`
+   * - `AGENT_MESSAGE_RECEIVED` (WebSocketManager: any agent→client message on the wire)
+   * - `MEANINGFUL_USER_ACTIVITY` with `AgentAudioDone` / `AgentDone` (turn complete after tool follow-up)
+   * - `FUNCTION_CALL_STARTED` (chained tool call = assistant continued)
+   * - max-wait timer (bounded fallback if the provider sends nothing)
    */
   private waitingForNextAgentMessageAfterFunctionResult = false;
   /**
-   * Fallback timer (not a second idle timer): after FUNCTION_CALL_COMPLETED we set waitingForNextAgentMessageAfterFunctionResult.
-   * If the backend never sends AgentAudioDone/AgentThinking/next message, we would block the idle timeout forever.
-   * This single timer fires after maxWaitForAgentReplyMs (capped at timeoutMs) and clears the waiting flag so the idle timeout can start.
-   * When we clear the flag via the normal path (e.g. MEANINGFUL_USER_ACTIVITY(AgentAudioDone)), we cancel this fallback with stopMaxWaitForAgentReplyTimer().
+   * If the provider never sends any of the signals above, we would block idle disconnect forever; this
+   * timer clears the latch after `maxWaitForAgentReplyMs` (capped by `timeoutMs`). Normal clears cancel it.
    */
   private maxWaitForAgentReplyTimeoutId: number | null = null;
   private logger: Logger;
@@ -102,22 +120,60 @@ export class IdleTimeoutService {
   }
 
   /**
+   * Apply the latest React-committed interaction snapshot (user speaking, agent phase, playback) in one call.
+   * The hook runs this from `useLayoutEffect` so DOM and state match before the idle-timeout service runs.
+   */
+  public applyCommittedInteractionState(
+    prev: Readonly<IdleTimeoutInteractionSnapshot>,
+    next: Readonly<IdleTimeoutInteractionSnapshot>
+  ): void {
+    const changed =
+      prev.agentState !== next.agentState ||
+      prev.isPlaying !== next.isPlaying ||
+      prev.isUserSpeaking !== next.isUserSpeaking;
+    if (!changed) {
+      return;
+    }
+
+    this.updateStateDirectly(
+      {
+        agentState: next.agentState,
+        isPlaying: next.isPlaying,
+        isUserSpeaking: next.isUserSpeaking,
+      },
+      { source: 'react-commit' }
+    );
+
+    if (prev.isUserSpeaking !== next.isUserSpeaking) {
+      this.handleEvent(
+        next.isUserSpeaking ? { type: 'USER_STARTED_SPEAKING' } : { type: 'USER_STOPPED_SPEAKING' }
+      );
+    }
+    if (prev.agentState !== next.agentState) {
+      this.handleEvent({ type: 'AGENT_STATE_CHANGED', state: next.agentState });
+    }
+    if (prev.isPlaying !== next.isPlaying) {
+      this.handleEvent({ type: 'PLAYBACK_STATE_CHANGED', isPlaying: next.isPlaying });
+    }
+  }
+
+  /**
    * Directly update state (bypasses event system)
    * This is used when events aren't arriving but we know the state has changed
    * (e.g., DOM shows state has changed but useEffect didn't fire)
    */
-  public updateStateDirectly(state: Partial<IdleTimeoutState>): void {
+  public updateStateDirectly(state: Partial<IdleTimeoutState>, options?: UpdateStateDirectlyOptions): void {
     const prevState = { ...this.currentState };
-    
-    // Issue #489: When we have an active timeout and this update would disable resets (and thus
-    // stop the timeout), the state may be stale (e.g. hook effect ran with pre-commit state).
-    // Defer: re-read from stateGetter next tick and then run updateTimeoutBehavior, so we don't
-    // stop the timeout on stale state. If state is still "blocking" after the tick, we'll stop then.
+    const skipDefer = options?.source === 'react-commit';
+
+    // Disconnect countdown is running and a direct state update would look "busy" and cancel it — but that
+    // update may predate what React has committed. Defer one tick and re-read live UI via stateGetter;
+    // only then decide whether to cancel the countdown.
     const wouldDisable =
       (state.agentState !== undefined && state.agentState !== 'idle' && state.agentState !== 'listening') ||
       (state.isPlaying !== undefined && state.isPlaying) ||
       (state.isUserSpeaking !== undefined && state.isUserSpeaking);
-    if (this.timeoutId !== null && wouldDisable) {
+    if (!skipDefer && this.timeoutId !== null && wouldDisable) {
       this.log('updateStateDirectly() would disable resets while timeout active; deferring to next tick and re-reading state');
       window.setTimeout(() => {
         if (this.stateGetter) {
@@ -208,18 +264,7 @@ export class IdleTimeoutService {
             this.log('AGENT_STATE_CHANGED to ' + event.state + ' - agent became active, no longer waiting');
           }
         }
-        
-        // Issue #373: If agent enters thinking state, stop any running timeout (unless we might have
-        // stale state from the hook - Issue #489: when we have a timeout we skip stop to avoid
-        // clearing a timeout we just started after AgentAudioDone).
-        if (event.state === 'thinking') {
-          this.log('Agent entered thinking state - stopping any running timeout unless skip (active timeout)');
-          if (this.timeoutId === null) {
-            this.stopTimeout();
-          }
-          this.disableResets(this.timeoutId !== null); // skip stop when timeout active (may be stale)
-        }
-        
+
         // CRITICAL: If agent becomes idle and playback has stopped, ensure timeout starts
         // This handles the case where AGENT_STATE_CHANGED with 'idle' arrives
         // after PLAYBACK_STATE_CHANGED with isPlaying=false
@@ -229,8 +274,9 @@ export class IdleTimeoutService {
             !this.currentState.isUserSpeaking) {
           // Agent is idle and playback stopped, so enable resets and start timeout
           this.enableResetsAndUpdateBehavior();
-        } else if (event.state !== 'thinking') {
-          // Normal update behavior (skip if we already handled thinking state above)
+        } else {
+          // Assistant is mid-turn (thinking/speaking/etc.): normally cancel a running "disconnect if idle" countdown
+          // so we do not hang up while the user is still getting a response (see updateTimeoutBehavior).
           this.updateTimeoutBehavior();
         }
         break;
@@ -262,7 +308,9 @@ export class IdleTimeoutService {
           this.stopMaxWaitForAgentReplyTimer();
           if (this.waitingForNextAgentMessageAfterFunctionResult) {
             this.waitingForNextAgentMessageAfterFunctionResult = false;
-            this.log('MEANINGFUL_USER_ACTIVITY(' + event.activity + ') - agent turn done, no longer waiting for next agent message');
+            this.log(
+              'MEANINGFUL_USER_ACTIVITY(' + event.activity + ') — assistant turn complete; clearing post-tool idle block if set'
+            );
           }
         }
         // CRITICAL FIX: If agent is idle and not playing, enable resets and RESET timeout
@@ -300,7 +348,9 @@ export class IdleTimeoutService {
         // Issue #487 (voice-commerce #1058): App sent function result; agent is still busy until next agent message.
         if (this.activeFunctionCalls.size === 0) {
           this.waitingForNextAgentMessageAfterFunctionResult = true;
-          this.log('Waiting for next agent message after function result - idle timeout will not start');
+          this.log(
+            'Tool output sent — blocking idle disconnect until assistant activity (thinking/speaking, WS message, AgentAudioDone, or max-wait)'
+          );
           this.startMaxWaitForAgentReplyTimer();
         }
         // If no more active function calls, update behavior (timeout still must not start until AGENT_MESSAGE_RECEIVED or max-wait fires)
@@ -314,7 +364,7 @@ export class IdleTimeoutService {
         this.stopMaxWaitForAgentReplyTimer();
         if (this.waitingForNextAgentMessageAfterFunctionResult) {
           this.waitingForNextAgentMessageAfterFunctionResult = false;
-          this.log('AGENT_MESSAGE_RECEIVED - no longer waiting for next agent message');
+          this.log('AGENT_MESSAGE_RECEIVED — assistant traffic seen; clearing post-tool idle block if set');
         }
         this.updateTimeoutBehavior();
         break;
@@ -343,8 +393,8 @@ export class IdleTimeoutService {
   /**
    * Check if timeout can start based on current state.
    * Timeout is paused until first user activity; after that it can start when conditions are idle.
-   * waitingForNextAgentMessageAfterFunctionResult: block until we have a signal that the agent
-   * is working (thinking/speaking) or any agent message, or the max-wait fallback (capped at timeoutMs).
+   * Tool-output latch (see `waitingForNextAgentMessageAfterFunctionResult`): block idle disconnect until
+   * assistant activity or max-wait, as documented on that field.
    */
   private canStartTimeout(state: IdleTimeoutState = this.currentState): boolean {
     return this.hasSeenUserActivityThisSession &&
@@ -369,19 +419,82 @@ export class IdleTimeoutService {
   }
 
   /**
-   * Update timeout behavior based on current state
+   * User- or tool-driven reasons to cancel a running idle disconnect countdown immediately.
+   * These are never treated as "late" signals: the user is talking, a tool call is in flight, or we are waiting
+   * for the assistant's next message after the app sent a function result.
+   */
+  private isUserOrToolSessionBlockingIdleClose(): boolean {
+    return (
+      this.currentState.isUserSpeaking ||
+      this.hasActiveFunctionCalls() ||
+      this.waitingForNextAgentMessageAfterFunctionResult
+    );
+  }
+
+  /**
+   * **Why two opinions can disagree:** The service updates from **effect-driven events** (same tick as React
+   * state, but not always the same ordering as "what the user already sees"). The `stateGetter` reads the
+   * component's **current** React snapshot. Right after a turn completes, it is common for one more
+   * `AGENT_STATE_CHANGED` / `PLAYBACK_STATE_CHANGED` from the **previous** render to arrive — so the service
+   * briefly thinks "assistant busy" while the UI already shows "done". That is a **pipeline defect** in the
+   * strict sense; the robust fix is to emit idle-timeout inputs from a **single post-commit path** (e.g. one
+   * `useLayoutEffect`, or only from the reducer after dispatches settle) so event order matches UI. Until then,
+   * when a disconnect countdown is already running, we use the **live UI** (`stateGetter`) as tie-breaker:
+   * if it says idle-capable and the only mismatch is assistant/playback fields, treat the event as stale.
+   *
+   * **Why not user/tool flags here:** Those come from different sources (mic, function-call lifecycle, tool
+   * latch). They were not the source of the "late busy after real idle" bug; applying the same deferral to
+   * them would risk keeping a countdown when the user is actually talking or a tool is in flight.
+   */
+  private shouldIgnoreLateAssistantBusySignal(): boolean {
+    if (this.timeoutId === null || !this.stateGetter) {
+      return false;
+    }
+    if (this.hasActiveFunctionCalls() || this.waitingForNextAgentMessageAfterFunctionResult) {
+      return false;
+    }
+    const s = this.stateGetter();
+    if (!s || s.isUserSpeaking) {
+      return false;
+    }
+    const componentIdleReady =
+      this.isAgentIdle(s) && !s.isPlaying;
+    if (!componentIdleReady) {
+      return false;
+    }
+    const serviceClaimsAgentOrPlaybackBusy =
+      !this.isAgentIdle(this.currentState) ||
+      this.currentState.isPlaying ||
+      this.currentState.isUserSpeaking;
+    return serviceClaimsAgentOrPlaybackBusy;
+  }
+
+  /**
+   * Drive the "disconnect if everyone is idle" timer from the service's picture of the session.
+   *
+   * **User behavior**
+   * - When something real is going on (user speaking, tool call, assistant responding or audio playing), we
+   *   must not count down to disconnect — or we must **cancel** an already-running countdown so we do not hang
+   *   up mid-response.
+   * - When the session is truly idle (user quiet, assistant done, not playing), we allow the countdown to run
+   *   or start so the app can eventually close the connection after inactivity.
+   * - **Exception:** Assistant/playback can be **wrongly busy** in the event stream while the live UI is already
+   *   idle (`shouldIgnoreLateAssistantBusySignal`) — keep the countdown; see that method for why we cannot
+   *   rely on event order alone until a single post-commit source exists.
    */
   private updateTimeoutBehavior(): void {
     this.log(`updateTimeoutBehavior() called with state: isUserSpeaking=${this.currentState.isUserSpeaking}, agentState=${this.currentState.agentState}, isPlaying=${this.currentState.isPlaying}, isDisabled=${this.isDisabled}`);
-    // Issue #373: Also disable timeout if there are active function calls
     if (this.shouldDisableTimeoutResets()) {
-      // Issue #489: When blocking reason is only isPlaying/agentState (often stale from hook effect),
-      // do not stop an active timeout; only stop when user speaking, function calls, or waiting.
-      const onlyPlaybackOrAgentState =
-        !this.currentState.isUserSpeaking &&
-        !this.hasActiveFunctionCalls() &&
-        !this.waitingForNextAgentMessageAfterFunctionResult;
-      this.disableResets(onlyPlaybackOrAgentState);
+      if (this.isUserOrToolSessionBlockingIdleClose()) {
+        this.disableResets(false);
+      } else if (this.shouldIgnoreLateAssistantBusySignal()) {
+        this.log(
+          'updateTimeoutBehavior() - keep idle disconnect countdown: live UI already idle; ignoring late assistant/playback signal'
+        );
+        this.disableResets(true);
+      } else {
+        this.disableResets(false);
+      }
     } else {
       this.enableResets();
       // Start timeout when all conditions are idle
@@ -414,12 +527,12 @@ export class IdleTimeoutService {
     if (this.stateGetter) {
       const componentState = this.stateGetter();
       if (componentState) {
-        // Issue #489: When we have an active timeout, do not overwrite with component state that
-        // says isUserSpeaking: true. The component may not have committed USER_SPEAKING_STATE_CHANGE(false)
-        // yet (e.g. after AgentAudioDone we dispatch it after handleMeaningfulActivity), so stateGetter
-        // can return stale isUserSpeaking and we would incorrectly stop the timeout we just started.
+        // When a disconnect countdown just started, the live UI may still briefly report "user speaking"
+        // before React applies "user stopped". Do not trust that snapshot to cancel the countdown.
         if (this.timeoutId !== null && componentState.isUserSpeaking) {
-          this.log('checkAndStartTimeoutIfNeeded() - have active timeout and stateGetter says user speaking; skip overwrite to avoid stopping on stale state');
+          this.log(
+            'checkAndStartTimeoutIfNeeded() - idle countdown active; skipping state sync that would treat user as still speaking (prevents false cancel)'
+          );
         } else {
           this.currentState = componentState;
           stateToCheck = componentState;
@@ -506,13 +619,11 @@ export class IdleTimeoutService {
   }
 
   /**
-   * Disable idle timeout resets (during activity)
-   */
-  /**
-   * @param skipStopIfTimeoutActive - When true and we have an active timeout, set isDisabled but do not
-   * stop the timeout (Issue #489: avoids stopping on stale isPlaying/agentState from the hook's effect).
-   * When false or from USER_STARTED_SPEAKING, always stop. Pass true only when blocking reason is
-   * solely isPlaying or agentState (thinking/speaking); pass false for function calls, waiting, or isUserSpeaking.
+   * Mark the session as "not idle" for reset purposes (user or assistant activity).
+   *
+   * @param skipStopIfTimeoutActive - If true and a disconnect countdown is already running, keep it running
+   * (only used when {@link shouldIgnoreLateAssistantBusySignal} is true — live UI idle, late busy event).
+   * Otherwise pass false so we cancel any in-flight countdown whenever we know work is really happening.
    */
   private disableResets(skipStopIfTimeoutActive: boolean = false): void {
     this.log('disableResets() called');

--- a/tests/IdleTimeoutService.applyCommittedInteractionState.test.ts
+++ b/tests/IdleTimeoutService.applyCommittedInteractionState.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ *
+ * TDD: IdleTimeoutService.applyCommittedInteractionState — single post-commit entry point
+ * for React interaction snapshot (user speaking, agent phase, playback). Parity with the
+ * former hook sequence: merge snapshot then emit semantic transitions.
+ */
+
+import { IdleTimeoutService } from '../src/utils/IdleTimeoutService';
+
+describe('IdleTimeoutService.applyCommittedInteractionState', () => {
+  it('is defined (post-commit API exists)', () => {
+    const svc = new IdleTimeoutService({ timeoutMs: 5000, debug: false });
+    expect(typeof svc.applyCommittedInteractionState).toBe('function');
+    svc.destroy();
+  });
+
+  it('no-ops when prev and next are identical for the three fields', () => {
+    const svc = new IdleTimeoutService({ timeoutMs: 5000, debug: false });
+    const snap = { agentState: 'idle', isPlaying: false, isUserSpeaking: false };
+    const handleSpy = jest.spyOn(svc as unknown as { handleEvent: (e: unknown) => void }, 'handleEvent');
+    svc.applyCommittedInteractionState(snap, snap);
+    expect(handleSpy).not.toHaveBeenCalled();
+    handleSpy.mockRestore();
+    svc.destroy();
+  });
+
+  it('starts idle disconnect flow like UTTERANCE_END path: idle → user stops path via committed snapshot', () => {
+    jest.useFakeTimers();
+    const onTimeout = jest.fn();
+    const svc = new IdleTimeoutService({ timeoutMs: 10000, debug: false });
+    svc.onTimeout(onTimeout);
+    svc.setStateGetter(() => ({
+      agentState: 'idle',
+      isPlaying: false,
+      isUserSpeaking: false,
+    }));
+
+    const idle = { agentState: 'idle' as const, isPlaying: false, isUserSpeaking: false };
+    svc.applyCommittedInteractionState(idle, idle);
+
+    const speakingUser = { agentState: 'idle' as const, isPlaying: false, isUserSpeaking: true };
+    svc.applyCommittedInteractionState(idle, speakingUser);
+
+    const userDone = { agentState: 'idle' as const, isPlaying: false, isUserSpeaking: false };
+    svc.applyCommittedInteractionState(speakingUser, userDone);
+
+    expect(svc.isTimeoutActive()).toBe(true);
+    jest.advanceTimersByTime(10001);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+
+    jest.useRealTimers();
+    svc.destroy();
+  });
+
+  it('clears running idle countdown when committed snapshot moves to speaking (mid-turn protection)', () => {
+    jest.useFakeTimers();
+    const onTimeout = jest.fn();
+    const svc = new IdleTimeoutService({ timeoutMs: 10000, debug: false });
+    svc.onTimeout(onTimeout);
+
+    const idle = { agentState: 'idle' as const, isPlaying: false, isUserSpeaking: false };
+    svc.applyCommittedInteractionState(idle, idle);
+    svc.handleEvent({ type: 'UTTERANCE_END' });
+    expect(svc.isTimeoutActive()).toBe(true);
+
+    const speaking = { agentState: 'speaking' as const, isPlaying: false, isUserSpeaking: false };
+    svc.applyCommittedInteractionState(
+      { agentState: 'idle', isPlaying: false, isUserSpeaking: false },
+      speaking
+    );
+
+    expect(svc.isTimeoutActive()).toBe(false);
+    jest.advanceTimersByTime(10001);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    jest.useRealTimers();
+    svc.destroy();
+  });
+});

--- a/tests/agent-state-handling.test.ts
+++ b/tests/agent-state-handling.test.ts
@@ -307,9 +307,9 @@ describe('Agent State Message Handling', () => {
       expect(currentState.isUserSpeaking).toBe(false);
       
       jest.advanceTimersByTime(100);
-      // Issue #489: We do not stop an active timeout when agent goes to speaking (avoid stale state).
-      // A timeout may have been started after USER_STOPPED_SPEAKING when state was still idle.
-      expect(idleTimeoutService.isTimeoutActive()).toBe(true); // current design: timeout not stopped
+      // A countdown may have started after USER_STOPPED_SPEAKING while the agent was still idle; entering
+      // speaking must clear it so we do not close mid-turn (see agent-receipt-vs-playback-idle-timeout).
+      expect(idleTimeoutService.isTimeoutActive()).toBe(false);
       
       jest.useRealTimers();
     });
@@ -355,6 +355,65 @@ describe('Agent State Message Handling', () => {
       
       // Now timeout resets should work
       idleTimeoutService.handleEvent({ type: 'MEANINGFUL_USER_ACTIVITY', activity: 'after-idle' });
+    });
+  });
+
+  describe('IdleTimeoutService: idle disconnect countdown vs late assistant "busy" signals', () => {
+    it('keeps idle disconnect countdown when live UI is idle but a stale thinking event arrives', () => {
+      jest.useFakeTimers();
+      const onTimeout = jest.fn();
+      const svc = new IdleTimeoutService({ timeoutMs: 10000, debug: true });
+      svc.onTimeout(onTimeout);
+      svc.setStateGetter(() => ({
+        agentState: 'idle',
+        isPlaying: false,
+        isUserSpeaking: false,
+      }));
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });
+      svc.handleEvent({ type: 'PLAYBACK_STATE_CHANGED', isPlaying: false });
+      svc.handleEvent({ type: 'UTTERANCE_END' });
+      expect(svc.isTimeoutActive()).toBe(true);
+      // Stale hook: AGENT_STATE_CHANGED(thinking) arrives after idle was committed; deferral must not clear timer.
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'thinking' });
+      // checkAndStartTimeoutIfNeeded may sync agentState back from stateGetter to idle — timer must still run.
+      expect(svc.isTimeoutActive()).toBe(true);
+      jest.advanceTimersByTime(10001);
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+      jest.useRealTimers();
+      svc.destroy();
+    });
+
+    it('cancels idle disconnect countdown on thinking when there is no live UI snapshot (isolated service)', () => {
+      jest.useFakeTimers();
+      const svc = new IdleTimeoutService({ timeoutMs: 10000, debug: true });
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });
+      svc.handleEvent({ type: 'PLAYBACK_STATE_CHANGED', isPlaying: false });
+      svc.handleEvent({ type: 'UTTERANCE_END' });
+      expect(svc.isTimeoutActive()).toBe(true);
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'thinking' });
+      expect(svc.isTimeoutActive()).toBe(false);
+      jest.useRealTimers();
+      svc.destroy();
+    });
+
+    it('cancels idle disconnect countdown when live UI and events both show assistant thinking', () => {
+      jest.useFakeTimers();
+      const svc = new IdleTimeoutService({ timeoutMs: 10000, debug: true });
+      const getterState = { agentState: 'idle' as string, isPlaying: false, isUserSpeaking: false };
+      svc.setStateGetter(() => ({
+        agentState: getterState.agentState,
+        isPlaying: getterState.isPlaying,
+        isUserSpeaking: getterState.isUserSpeaking,
+      }));
+      svc.handleEvent({ type: 'UTTERANCE_END' });
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });
+      svc.handleEvent({ type: 'PLAYBACK_STATE_CHANGED', isPlaying: false });
+      expect(svc.isTimeoutActive()).toBe(true);
+      getterState.agentState = 'thinking';
+      svc.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'thinking' });
+      expect(svc.isTimeoutActive()).toBe(false);
+      jest.useRealTimers();
+      svc.destroy();
     });
   });
 
@@ -436,13 +495,11 @@ describe('Agent State Message Handling', () => {
       // Clear and test transition to agent speaking
       onIdleTimeoutActiveChange.mockClear();
       
-      // Trigger agent speaking. Issue #489: we do not stop an active timeout on thinking/speaking
-      // to avoid stopping on stale state, so timeout may remain active.
+      // Entering speaking stops any running idle countdown (mid-turn protection).
       testService.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'speaking' });
 
-      // Current design: timeout is not stopped when agent goes to speaking (avoid stale state)
-      expect(testService.isTimeoutActive()).toBe(true);
-      // onIdleTimeoutActiveChange is not called with false because we did not stop the timeout
+      expect(testService.isTimeoutActive()).toBe(false);
+      expect(onIdleTimeoutActiveChange).toHaveBeenCalledWith(false);
       
       testService.destroy();
     });
@@ -686,15 +743,14 @@ describe('Agent State Message Handling', () => {
       
       expect(idleTimeoutService.isTimeoutActive()).toBe(true);
       
-      // Agent starts speaking. Issue #489: we do not stop the timeout (avoid stale state).
+      // Agent starts speaking — idle countdown is cleared; it must not fire while the agent speaks.
       idleTimeoutService.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'speaking' });
-      expect(idleTimeoutService.isTimeoutActive()).toBe(true); // current design: not stopped
+      expect(idleTimeoutService.isTimeoutActive()).toBe(false);
       
-      // Fast-forward - callback will fire (timeout was not stopped)
       jest.advanceTimersByTime(10000);
-      expect(timeoutCallback).toHaveBeenCalledTimes(1);
+      expect(timeoutCallback).not.toHaveBeenCalled();
       
-      // Restart: go back to idle and advance again for a second fire
+      // Restart: go back to idle and advance again for a fire
       timeoutCallback.mockClear();
       idleTimeoutService.handleEvent({ type: 'PLAYBACK_STATE_CHANGED', isPlaying: false });
       idleTimeoutService.handleEvent({ type: 'AGENT_STATE_CHANGED', state: 'idle' });

--- a/tests/fixtures/mocks.ts
+++ b/tests/fixtures/mocks.ts
@@ -67,6 +67,8 @@ export const createMockAudioManager = () => ({
     resume: jest.fn(),
   }),
   abortPlayback: jest.fn(),
+  /** When true, AgentAudioDone/AgentDone must not force idle until playback ends (OpenAI proxy / TTS pipeline). */
+  isPlaybackActive: jest.fn().mockReturnValue(false),
 });
 
 /**

--- a/tests/hooks/useIdleTimeoutManager.post-commit.test.tsx
+++ b/tests/hooks/useIdleTimeoutManager.post-commit.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * TDD: useIdleTimeoutManager drives IdleTimeoutService only via applyCommittedInteractionState
+ * from useLayoutEffect after committed interaction fields change.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { IdleTimeoutService } from '../../src/utils/IdleTimeoutService';
+import { useIdleTimeoutManager } from '../../src/hooks/useIdleTimeoutManager';
+import type { VoiceInteractionState } from '../../src/utils/state/VoiceInteractionState';
+import { WebSocketManager } from '../../src/utils/websocket/WebSocketManager';
+
+jest.mock('../../src/utils/websocket/WebSocketManager');
+
+const baseState = (): VoiceInteractionState =>
+  ({
+    isUserSpeaking: false,
+    agentState: 'idle',
+    isPlaying: false,
+  }) as VoiceInteractionState;
+
+describe('useIdleTimeoutManager post-commit sync', () => {
+  let applySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    applySpy = jest.spyOn(IdleTimeoutService.prototype, 'applyCommittedInteractionState');
+  });
+
+  afterEach(() => {
+    applySpy.mockRestore();
+  });
+
+  it('calls applyCommittedInteractionState once per committed change to interaction fields', () => {
+    const mockWs = {} as unknown as WebSocketManager;
+    const ref = { current: mockWs };
+
+    const { rerender } = renderHook(
+      ({ s }: { s: VoiceInteractionState }) => useIdleTimeoutManager(s, ref, false),
+      { initialProps: { s: baseState() } }
+    );
+
+    expect(applySpy).toHaveBeenCalledTimes(1);
+
+    const s2 = { ...baseState(), agentState: 'speaking' } as VoiceInteractionState;
+    act(() => {
+      rerender({ s: s2 });
+    });
+
+    expect(applySpy).toHaveBeenCalledTimes(2);
+    const lastCall = applySpy.mock.calls[1];
+    expect(lastCall[0]).toMatchObject({
+      agentState: 'idle',
+      isPlaying: false,
+      isUserSpeaking: false,
+    });
+    expect(lastCall[1]).toMatchObject({
+      agentState: 'speaking',
+      isPlaying: false,
+      isUserSpeaking: false,
+    });
+  });
+});

--- a/tests/integration/agent-receipt-vs-playback-idle-timeout.test.tsx
+++ b/tests/integration/agent-receipt-vs-playback-idle-timeout.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ * @eslint-env jest
+ *
+ * AgentAudioDone / AgentDone are receipt-complete on the wire, not local playback complete.
+ * Premature receipt while AudioManager still reports active playback must not arm idle timeout
+ * or close the connection until playback actually finishes.
+ */
+
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { DeepgramVoiceInteractionHandle } from '../../src/types';
+import { createMockWebSocketManager, createMockAudioManager } from '../fixtures/mocks';
+import {
+  resetTestState,
+  createAgentOptions,
+  setupComponentAndConnect,
+  waitForEventListener,
+  MOCK_API_KEY,
+} from '../utils/component-test-helpers';
+import DeepgramVoiceInteraction from '../../src/components/DeepgramVoiceInteraction';
+
+jest.mock('../../src/utils/websocket/WebSocketManager');
+jest.mock('../../src/utils/audio/AudioManager');
+
+const { WebSocketManager } = require('../../src/utils/websocket/WebSocketManager');
+const { AudioManager } = require('../../src/utils/audio/AudioManager');
+
+const IDLE_TIMEOUT_MS = 10000;
+const TIMEOUT_BUFFER_MS = 500;
+
+describe('Agent receipt (AgentAudioDone) vs playback — idle timeout', () => {
+  let mockWebSocketManager: ReturnType<typeof createMockWebSocketManager> & {
+    _constructorOptions?: { onMeaningfulActivity?: (activity: string) => void };
+  };
+  let mockAudioManager: ReturnType<typeof createMockAudioManager>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    resetTestState();
+
+    mockWebSocketManager = createMockWebSocketManager() as ReturnType<typeof createMockWebSocketManager> & {
+      _constructorOptions?: { onMeaningfulActivity?: (activity: string) => void };
+    };
+    mockAudioManager = createMockAudioManager();
+    WebSocketManager.mockImplementation((options: any) => {
+      mockWebSocketManager._constructorOptions = options;
+      return mockWebSocketManager;
+    });
+    AudioManager.mockImplementation(() => mockAudioManager);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not close on idle when AgentAudioDone arrives while isPlaybackActive() is still true; closes after playback ends', async () => {
+    mockAudioManager.isPlaybackActive.mockReturnValue(true);
+
+    const agentOptions = createAgentOptions({ idleTimeoutMs: IDLE_TIMEOUT_MS });
+    const ref = React.createRef<DeepgramVoiceInteractionHandle>();
+
+    render(
+      <DeepgramVoiceInteraction
+        ref={ref}
+        apiKey={MOCK_API_KEY}
+        agentOptions={agentOptions}
+      />
+    );
+
+    await setupComponentAndConnect(ref, mockWebSocketManager);
+    const eventListener = await waitForEventListener(mockWebSocketManager);
+
+    act(() => {
+      mockWebSocketManager._constructorOptions?.onMeaningfulActivity?.('test');
+    });
+
+    // Ensure AudioManager exists (same as OpenAI proxy binary PCM path). handleAgentAudio is async and not awaited by the WS handler — flush microtasks before receipt events.
+    await act(async () => {
+      eventListener?.({ type: 'binary', data: new ArrayBuffer(64) });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(AudioManager).toHaveBeenCalled();
+
+    act(() => {
+      eventListener?.({ type: 'message', data: { type: 'AgentStartedSpeaking' } });
+    });
+    act(() => {
+      eventListener?.({ type: 'message', data: { type: 'AgentAudioDone' } });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Component must consult AudioManager before treating wire receipt as playback-complete
+    expect(mockAudioManager.isPlaybackActive).toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(IDLE_TIMEOUT_MS + TIMEOUT_BUFFER_MS);
+    });
+
+    expect(mockWebSocketManager.close).not.toHaveBeenCalled();
+
+    const audioListener = mockAudioManager.addEventListener.mock.calls[0]?.[0] as
+      | ((e: { type: string; isPlaying?: boolean }) => void)
+      | undefined;
+    expect(audioListener).toBeDefined();
+
+    mockAudioManager.isPlaybackActive.mockReturnValue(false);
+
+    await act(async () => {
+      audioListener!({ type: 'playing', isPlaying: false });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(IDLE_TIMEOUT_MS + TIMEOUT_BUFFER_MS);
+    });
+
+    expect(mockWebSocketManager.close).toHaveBeenCalled();
+  });
+});

--- a/tests/integration/openai-proxy-integration.test.ts
+++ b/tests/integration/openai-proxy-integration.test.ts
@@ -3469,6 +3469,75 @@ describe('OpenAI proxy integration (Issue #381)', () => {
   }, 8000);
 
   /**
+   * Voice-commerce #1118: upstream may send response.output_audio.delta before response.output_text.done.
+   * Agent receipt (AgentDone/AgentAudioDone) must be sent once when audio completes, not again on output_text.done
+   * (onResponseEnded clears the per-response sent flag; without deferral the client would get duplicate agent-done).
+   */
+  itMockOnly('Voice-commerce #1118: single AgentDone/AgentAudioDone when PCM precedes output_text.done', (done) => {
+    mockSendOutputAudioBeforeText = true;
+    const sequence: string[] = [];
+    let finished = false;
+    const client = new WebSocket(`ws://localhost:${proxyPort}${PROXY_PATH}`);
+    const clearFallback = scheduleFallbackTimeout(8000, () => {
+      if (finished) return;
+      finished = true;
+      try {
+        client.close();
+      } catch {
+        /* ignore */
+      }
+      done(new Error('timeout waiting for ConversationText (assistant)'));
+    });
+    const finish = (err?: Error) => {
+      if (finished) return;
+      finished = true;
+      clearFallback();
+      try {
+        client.close();
+      } catch {
+        /* ignore */
+      }
+      if (err) done(err);
+      else done();
+    };
+    client.on('open', () => {
+      client.send(JSON.stringify({ type: 'Settings', agent: { think: { prompt: 'Hi' } } }));
+    });
+    client.on('message', (data: Buffer) => {
+      if (finished) return;
+      if (data.length > 0 && data[0] !== 0x7b) {
+        sequence.push('binary');
+        return;
+      }
+      try {
+        const msg = JSON.parse(data.toString()) as { type?: string; role?: string };
+        if (!msg.type) return;
+        sequence.push(msg.type);
+        if (msg.type === 'SettingsApplied') {
+          client.send(JSON.stringify({ type: 'InjectUserMessage', content: 'Say hi' }));
+        }
+        if (msg.type === 'ConversationText' && msg.role === 'assistant') {
+          try {
+            expect(sequence.filter((t) => t === 'AgentDone').length).toBe(1);
+            expect(sequence.filter((t) => t === 'AgentAudioDone').length).toBe(1);
+            const binIdx = sequence.indexOf('binary');
+            const audioDoneIdx = sequence.indexOf('AgentAudioDone');
+            expect(binIdx).toBeGreaterThanOrEqual(0);
+            expect(audioDoneIdx).toBeGreaterThan(binIdx);
+          } catch (e) {
+            finish(e as Error);
+            return;
+          }
+          finish();
+        }
+      } catch (e) {
+        finish(e as Error);
+      }
+    });
+    client.on('error', (err) => finish(err));
+  }, 12000);
+
+  /**
    * Protocol §2.1: Client messages queued until upstream open, then drained in order.
    * Client sends Settings then InjectUserMessage immediately; assert upstream receives session.update then conversation.item.create.
    */


### PR DESCRIPTION
## Closes #527

### Problem
- Idle disconnect could fire while the assistant turn was still active / TTS still playing (receipt vs playback).
- Proxy could send `AgentAudioDone` on `response.output_text.done` after PCM had already streamed, arming idle too early (Voice-commerce #1118).

### Changes
- **IdleTimeoutService / `useIdleTimeoutManager`:** Post-commit sync (`applyCommittedInteractionState`), clearer busy/idle rules, late-assistant-signal handling; `IdleTimeoutInteractionSnapshot` type.
- **OpenAI proxy:** Defer `AgentAudioDone` from `output_text.done` when `output_audio.delta` was received for the response.
- **Tests:** Integration `agent-receipt-vs-playback-idle-timeout`, `IdleTimeoutService.applyCommittedInteractionState`, hook post-commit test, openai-proxy mock **Voice-commerce #1118**, agent-state-handling updates, mocks.

### Release note
Target **main** (not `release/v0.10.3`); v0.10.3 was reset; work lives on this branch per #527.

### Qualification
With API keys: `USE_REAL_APIS=1` on relevant proxy/integration/E2E paths per project checklist.

Made with [Cursor](https://cursor.com)