### PR TITLE
fix(voice-agent-backend): queue OpenAI relay messages until upstream open (#571)

### DIFF
--- a/docs/issues/ISSUE-571/CURRENT-STATUS.md
+++ b/docs/issues/ISSUE-571/CURRENT-STATUS.md
@@ -1,0 +1,32 @@
+# Issue #571 — current status
+
+**Last updated:** 2026-04-10
+
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) — **open** (close after fix merged and tests green)
+
+**Branch:** `issue-571`
+
+---
+
+## Snapshot
+
+| Area | State |
+|------|--------|
+| **Bug** | `createOpenAIWss` registers `clientWs.on('message')` only inside `upstream.on('open')`; frames sent before upstream is open are **dropped** (no queue). |
+| **Impact** | Early **Settings** can be lost → translator never applies session → audio stuck in `pendingAudioQueue`; no agent response. |
+| **Reference implementation** | `createDeepgramWss` in the same file (`attach-upgrade.js`) queues client → upstream until upstream is `OPEN`. |
+| **Fix** | Not implemented yet — docs + branch only. |
+| **Tests** | No failing/regression test for this relay race yet (add per TDD). |
+
+---
+
+## Acceptance criteria (from GitHub)
+
+- [ ] Client → upstream messages sent before upstream `OPEN` are forwarded after upstream opens.
+- [ ] Automated tests cover the relay path (extend `tests/voice-agent-backend-attach-upgrade-upstream.test.ts` or add focused tests).
+
+---
+
+## Next
+
+See [NEXT-STEP.md](./NEXT-STEP.md).

--- a/docs/issues/ISSUE-571/CURRENT-STATUS.md
+++ b/docs/issues/ISSUE-571/CURRENT-STATUS.md
@@ -12,18 +12,18 @@
 
 | Area | State |
 |------|--------|
-| **Bug** | `createOpenAIWss` registers `clientWs.on('message')` only inside `upstream.on('open')`; frames sent before upstream is open are **dropped** (no queue). |
-| **Impact** | Early **Settings** can be lost → translator never applies session → audio stuck in `pendingAudioQueue`; no agent response. |
+| **Bug (historical)** | `createOpenAIWss` used to register `clientWs.on('message')` only inside `upstream.on('open')`; frames sent before upstream was open were **dropped**. |
+| **Impact** | Early **Settings** could be lost → translator never applies session → audio stuck in `pendingAudioQueue`; no agent response. |
 | **Reference implementation** | `createDeepgramWss` in the same file (`attach-upgrade.js`) queues client → upstream until upstream is `OPEN`. |
-| **Fix** | Not implemented yet — docs + branch only. |
-| **Tests** | No failing/regression test for this relay race yet (add per TDD). |
+| **Fix** | **On `issue-571`:** client→upstream `messageQueue`, immediate `clientWs.on('message')`, flush on `upstream.on('open')`; early `clientWs` close/error tears down upstream (`CONNECTING` \| `OPEN`). |
+| **Tests** | `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js` — delayed upstream `verifyClient` so client sends while relay→upstream is still held. |
 
 ---
 
 ## Acceptance criteria (from GitHub)
 
-- [ ] Client → upstream messages sent before upstream `OPEN` are forwarded after upstream opens.
-- [ ] Automated tests cover the relay path (extend `tests/voice-agent-backend-attach-upgrade-upstream.test.ts` or add focused tests).
+- [x] Client → upstream messages sent before upstream `OPEN` are forwarded after upstream opens.
+- [x] Automated tests cover the relay path (new `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`).
 
 ---
 

--- a/docs/issues/ISSUE-571/CURRENT-STATUS.md
+++ b/docs/issues/ISSUE-571/CURRENT-STATUS.md
@@ -29,4 +29,4 @@
 
 ## Next
 
-See [NEXT-STEP.md](./NEXT-STEP.md).
+See [NEXT-STEP.md](./NEXT-STEP.md). For the **0.11.1 / 0.2.13** patch, use [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md).

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -1,0 +1,27 @@
+# Issue #571 — next step
+
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
+
+---
+
+## Done (this slice)
+
+Branch **`issue-571`** and in-repo docs under `docs/issues/ISSUE-571/` (README, TRACKING, CURRENT-STATUS, NEXT-STEP).
+
+---
+
+## Recommended follow-ups
+
+1. **RED** — Add a Jest test that simulates `createOpenAIWss`: client sends a message while the upstream `WebSocket` is still connecting, then upstream fires `open`; assert the upstream received the payload after open (binary and text cases if both matter).
+2. **GREEN** — In `packages/voice-agent-backend/src/attach-upgrade.js`, implement a client→upstream `messageQueue` + flush on `upstream.on('open')`, mirroring `createDeepgramWss`; register `clientWs.on('message')` immediately on connection. Revisit `close` / `error` handler attachment so a client disconnect during upstream connect is still handled cleanly.
+3. **REFACTOR** — Keep duplication minimal vs Deepgram path; run `npm test` for affected packages / root.
+4. **PR** — Open PR from `issue-571`, link #571 (`Fixes` or `Closes` as appropriate).
+5. **Qualification** — If reviewers or release notes require it: proxy-mode E2E and/or integration per [.cursorrules](../../../.cursorrules) and release checklist for timing-sensitive relay changes.
+6. **Close issue** — After merge, close #571 on GitHub and set [README.md](./README.md) status to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
+
+---
+
+## References
+
+- [README.md](./README.md) — problem statement and file pointers.
+- [TRACKING.md](./TRACKING.md) — checkbox TDD list.

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -15,8 +15,9 @@
 ## Recommended follow-ups
 
 1. **PR** — Open PR from `issue-571`, link #571 (`Fixes` / `Closes` as appropriate).
-2. **Qualification** — If the release touches relay timing: proxy-mode E2E and/or integration per [.cursorrules](../../../.cursorrules) and the release checklist.
-3. **Close issue** — After merge, close #571 on GitHub and set [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
+2. **Patch release** — Follow [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md): **v0.11.1** + **@signal-meaning/voice-agent-backend 0.2.13** (or document a backend-only exception on #571 per [PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)).
+3. **Qualification** — Real-API integration and/or OpenAI proxy E2E slice when qualifying relay timing (see checklist and [.cursorrules](../../../.cursorrules)).
+4. **Close issue** — After merge and publish, close #571 on GitHub and set [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
 
 ---
 

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -14,8 +14,8 @@
 
 ## Recommended follow-ups
 
-1. **PR** — Open PR from `issue-571`, link #571 (`Fixes` / `Closes` as appropriate).
-2. **Patch release** — Follow [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md): **v0.11.1** + **@signal-meaning/voice-agent-backend 0.2.13** (or document a backend-only exception on #571 per [PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)).
+1. **PR** — **[#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572)** (`issue-571` → `main`, **Closes #571**). Review and merge.
+2. **Patch release** — After merge, follow [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md): **v0.11.1** + **@signal-meaning/voice-agent-backend 0.2.13** (or document a backend-only exception on #571 per [PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)).
 3. **Qualification** — Real-API integration and/or OpenAI proxy E2E slice when qualifying relay timing (see checklist and [.cursorrules](../../../.cursorrules)).
 4. **Close issue** — After merge and publish, close #571 on GitHub and set [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
 

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -6,18 +6,17 @@
 
 ## Done (this slice)
 
-Branch **`issue-571`** and in-repo docs under `docs/issues/ISSUE-571/` (README, TRACKING, CURRENT-STATUS, NEXT-STEP).
+- Branch **`issue-571`** and docs under `docs/issues/ISSUE-571/`.
+- **TDD:** `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js` (delayed upstream `verifyClient` + `upstreamVerifyInvoked` so the client send races ahead of `cb(true)`).
+- **Implementation:** `packages/voice-agent-backend/src/attach-upgrade.js` — `createOpenAIWss` queues client→upstream until `upstream` is `OPEN`, mirrors Deepgram pattern; teardown if client disconnects while upstream is still connecting.
 
 ---
 
 ## Recommended follow-ups
 
-1. **RED** — Add a Jest test that simulates `createOpenAIWss`: client sends a message while the upstream `WebSocket` is still connecting, then upstream fires `open`; assert the upstream received the payload after open (binary and text cases if both matter).
-2. **GREEN** — In `packages/voice-agent-backend/src/attach-upgrade.js`, implement a client→upstream `messageQueue` + flush on `upstream.on('open')`, mirroring `createDeepgramWss`; register `clientWs.on('message')` immediately on connection. Revisit `close` / `error` handler attachment so a client disconnect during upstream connect is still handled cleanly.
-3. **REFACTOR** — Keep duplication minimal vs Deepgram path; run `npm test` for affected packages / root.
-4. **PR** — Open PR from `issue-571`, link #571 (`Fixes` or `Closes` as appropriate).
-5. **Qualification** — If reviewers or release notes require it: proxy-mode E2E and/or integration per [.cursorrules](../../../.cursorrules) and release checklist for timing-sensitive relay changes.
-6. **Close issue** — After merge, close #571 on GitHub and set [README.md](./README.md) status to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
+1. **PR** — Open PR from `issue-571`, link #571 (`Fixes` / `Closes` as appropriate).
+2. **Qualification** — If the release touches relay timing: proxy-mode E2E and/or integration per [.cursorrules](../../../.cursorrules) and the release checklist.
+3. **Close issue** — After merge, close #571 on GitHub and set [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
 
 ---
 

--- a/docs/issues/ISSUE-571/README.md
+++ b/docs/issues/ISSUE-571/README.md
@@ -48,7 +48,7 @@ Also consider registering **close / error** handlers in a way that does not depe
 
 ## Release / qualification
 
-If the fix ships in a release that touches proxy relay behavior, follow [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md) and project rules: run relevant integration/E2E with mocks in CI; use real APIs where the change affects ordering or timing.
+Patch release (**0.11.1** / **0.2.13**) checklist: [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md). Authoritative template: [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md). Use real APIs where the change affects proxy relay ordering or timing (see [.cursorrules](../../../.cursorrules)).
 
 ---
 
@@ -56,6 +56,7 @@ If the fix ships in a release that touches proxy relay behavior, follow [.github
 
 | Doc | Purpose |
 |-----|---------|
+| [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md) | Patch release steps: **v0.11.1** + **voice-agent-backend 0.2.13**. |
 | [CURRENT-STATUS.md](./CURRENT-STATUS.md) | Snapshot and acceptance checkboxes. |
 | [NEXT-STEP.md](./NEXT-STEP.md) | Ordered follow-ups (TDD, PR, close-out). |
 | [TRACKING.md](./TRACKING.md) | Checklist while implementing #571. |

--- a/docs/issues/ISSUE-571/README.md
+++ b/docs/issues/ISSUE-571/README.md
@@ -1,6 +1,6 @@
 # Issue #571 — OpenAI relay drops pre-upstream-open client messages
 
-**Status:** Open — implementation on branch **`issue-571`**.
+**Status:** Open on GitHub — **fix + tests on branch `issue-571`** (queue in `createOpenAIWss`); pending PR / merge / close.
 
 **GitHub:** [#571 — OpenAI relay (createOpenAIWss) drops client messages until upstream opens — queue like Deepgram path](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
 

--- a/docs/issues/ISSUE-571/README.md
+++ b/docs/issues/ISSUE-571/README.md
@@ -1,0 +1,59 @@
+# Issue #571 — OpenAI relay drops pre-upstream-open client messages
+
+**Status:** Open — implementation on branch **`issue-571`**.
+
+**GitHub:** [#571 — OpenAI relay (createOpenAIWss) drops client messages until upstream opens — queue like Deepgram path](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
+
+**Branch:** `issue-571`
+
+---
+
+## Problem
+
+In `@signal-meaning/voice-agent-backend`, `createOpenAIWss` (`packages/voice-agent-backend/src/attach-upgrade.js`) registers `clientWs.on('message')` only inside `upstream.on('open')`. The browser’s WebSocket is already open after the Express upgrade, so the client may send **Settings** (and other frames) while the upstream socket to the translator (e.g. `ws://127.0.0.1:3011/...`) is still connecting. Those frames have **no listener** yet and are **dropped**; there is no queue.
+
+## Why responses never arrive
+
+The translator (`scripts/openai-proxy/server.ts`) expects Settings to drive `session.update` to OpenAI. If Settings never arrives, `hasSentSettingsApplied` stays false and binary audio is held in `pendingAudioQueue` indefinitely. The user sees no agent audio or completion.
+
+## Contrast
+
+- **`createDeepgramWss`** (same file): registers `clientWs.on('message')` immediately and pushes to `messageQueue` until `deepgramWs` is `OPEN`, then drains on `open`.
+- **Translator `server.ts`**: registers `(clientWs).on('message', …)` in the connection path immediately and uses `clientMessageQueue` when upstream is not open.
+
+Direct test-app → translator connections avoid the relay race; **browser → backend forwarder → translator** does not.
+
+## Proposed fix
+
+Mirror the Deepgram pattern in `createOpenAIWss`:
+
+1. Register `clientWs.on('message')` as soon as the client connection is accepted.
+2. If `upstream.readyState !== WebSocket.OPEN`, push `{ data, isBinary }` to a queue.
+3. On `upstream.on('open')`, flush the queue to `upstream.send`, then keep piping as today.
+
+Also consider registering **close / error** handlers in a way that does not depend solely on `upstream.on('open')` (so client disconnect during connect is still handled); align with whatever minimal behavior Deepgram path uses after review.
+
+## Acceptance (from GitHub #571)
+
+- Client → upstream messages sent before upstream `OPEN` are forwarded after upstream opens.
+- Automated tests cover the relay path so this cannot regress (extend `tests/voice-agent-backend-attach-upgrade-upstream.test.ts` or add focused tests).
+
+## References
+
+| Location | Notes |
+|----------|--------|
+| `packages/voice-agent-backend/src/attach-upgrade.js` | `createOpenAIWss` (~L182–206), `createDeepgramWss` (~L57–175) |
+| `packages/voice-agent-backend/scripts/openai-proxy/server.ts` | Immediate client `message` handler; `clientMessageQueue`; `hasSentSettingsApplied` / `pendingAudioQueue` |
+| [docs/issues/ISSUE-522/FINDINGS.md](../ISSUE-522/FINDINGS.md) | Hypothesis **F1** (forwarder drops/reorders) — #571 is a concrete instance for early Settings |
+
+## Release / qualification
+
+If the fix ships in a release that touches proxy relay behavior, follow [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md) and project rules: run relevant integration/E2E with mocks in CI; use real APIs where the change affects ordering or timing.
+
+---
+
+## Local docs
+
+| Doc | Purpose |
+|-----|---------|
+| [TRACKING.md](./TRACKING.md) | Checklist while implementing #571. |

--- a/docs/issues/ISSUE-571/README.md
+++ b/docs/issues/ISSUE-571/README.md
@@ -56,4 +56,6 @@ If the fix ships in a release that touches proxy relay behavior, follow [.github
 
 | Doc | Purpose |
 |-----|---------|
+| [CURRENT-STATUS.md](./CURRENT-STATUS.md) | Snapshot and acceptance checkboxes. |
+| [NEXT-STEP.md](./NEXT-STEP.md) | Ordered follow-ups (TDD, PR, close-out). |
 | [TRACKING.md](./TRACKING.md) | Checklist while implementing #571. |

--- a/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
@@ -1,0 +1,137 @@
+# Issue #571: Release checklist — patch (backend relay fix)
+
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
+
+**Scope:** Patch shipping **Issue #571** — `createOpenAIWss` queues client→upstream WebSocket frames until the upstream socket is `OPEN` (matches `createDeepgramWss`). Fixes lost **Settings** when the browser connects through the Express relay before the translator handshake completes.
+
+**Authoritative checklist:** Mirror [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md) on the GitHub release issue (if you open one) or on **#571**. This file is the **repo-local** companion: versions, paths, and commands.
+
+**Publishing note:** Per [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md), the GitHub Release tag **`vX.X.X`** follows the **root** component version. This checklist assumes a **coordinated patch**: bump **both** packages so tag **`v0.11.1`** matches root **`0.11.1`** and **`@signal-meaning/voice-agent-backend`** ships **`0.2.13`**. If you intentionally ship **backend only**, document that on #571 and adjust branch/tag steps with maintainers (CI publishes both packages when the workflow runs).
+
+---
+
+## Release v0.11.1 (component) and 0.2.13 (backend)
+
+### Overview
+
+**Release type:** **Patch** (bug fix; no intentional breaking API change).
+
+**Packages:**
+
+| Package | Location | Version for this release |
+|---------|----------|--------------------------|
+| **@signal-meaning/voice-agent-react** | Root `package.json` | **0.11.1** (Git tag **`v0.11.1`**, branch **`release/v0.11.1`**) |
+| **@signal-meaning/voice-agent-backend** | `packages/voice-agent-backend/package.json` | **0.2.13** |
+
+**CHANGELOG entry (Issue #571):** Patch release — OpenAI relay (`createOpenAIWss` in `packages/voice-agent-backend/src/attach-upgrade.js`) queues client messages until upstream WebSocket is open, preventing dropped **Settings** and stuck sessions when clients use the backend upgrade path (browser → relay → translator). Regression test: `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`.
+
+**Documentation set (patch):** `docs/releases/v0.11.1/` — `CHANGELOG.md`, `PACKAGE-STRUCTURE.md` (from [docs/releases/PACKAGE-STRUCTURE.template.md](../../releases/PACKAGE-STRUCTURE.template.md)), optional `RELEASE-NOTES.md`. No `MIGRATION.md` unless a breaking change is discovered.
+
+### Progress
+
+_(Fill in as you execute the release.)_
+
+- **Pre-publish:** _dates / PR / branch_
+- **Qualification:** _OpenAI proxy integration / E2E slice if run_
+- **Publish:** _GitHub Release ref, workflow run URL_
+- **Post-release:** _merge `release/v0.11.1` → `main`, close #571, sync issue docs_
+
+---
+
+### Pre-merge (before `release/v0.11.1`)
+
+- [ ] **#571 fix on `main`:** PR merged that contains the queue fix + Jest test (or equivalent), linked to **#571**.
+- [ ] **Code review complete** on the merge commit that will be released.
+
+---
+
+### Pre-Release Preparation
+
+- [ ] **Tests passing**
+  - [ ] **CI bar:** `npm run lint` then `npm run test:mock`
+  - [ ] **Issue #571 unit test:** `npm test -- tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`
+  - [ ] **Attach-upgrade / #441:** `npm test -- tests/voice-agent-backend-attach-upgrade-upstream.test.ts`
+  - [ ] **Full Jest (recommended):** `npm test`
+  - [ ] **Relay / proxy timing (recommended when `OPENAI_API_KEY` available):**  
+    `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`
+  - [ ] **Upstream event coverage:** `npm test -- tests/openai-proxy-event-coverage.test.ts`
+  - [ ] **OpenAI proxy E2E slice (recommended):** from **`test-app`**, with backend + dev server running (`npm run backend`, `npm run dev`), e.g.  
+    `E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true E2E_USE_HTTP=1 USE_REAL_APIS=1 npm run test:e2e:openai`  
+    See [test-app/tests/e2e/README.md](../../../test-app/tests/e2e/README.md).
+- [ ] **Linting clean:** `npm run lint`
+- [ ] **npm audit:** `npm audit --audit-level=high` — exit 0
+- [ ] **Breaking changes:** None expected; if any surface, document in `docs/API-REFERENCE.md` and release notes
+
+---
+
+### Version Management
+
+- [ ] Root `package.json` (and root lockfile if applicable) → **0.11.1**
+- [ ] `packages/voice-agent-backend/package.json` → **0.2.13**
+- [ ] Any workspace consumer that pins backend (e.g. test-app) updated if your policy requires a strict range bump
+
+---
+
+### Documentation (`docs/releases/v0.11.1/`)
+
+- [ ] `CHANGELOG.md` — link **#571**; describe relay queue fix
+- [ ] `PACKAGE-STRUCTURE.md` — from template; placeholders for **0.11.1**
+- [ ] Optional: `RELEASE-NOTES.md`
+- [ ] Validate: `npm run validate:release-docs 0.11.1`
+
+---
+
+### Build and Package
+
+- [ ] Rely on **CI** for publish builds; do not commit `dist/` or `.tgz`
+- [ ] Optional local: `npm run clean && npm run build && npm run validate`
+
+---
+
+### Git Operations
+
+- [ ] Branch **`release/v0.11.1`** from the commit that includes version bumps + `docs/releases/v0.11.1/`
+- [ ] Push: `git push -u origin release/v0.11.1`
+- [ ] **Do not delete** `release/v0.11.1` after merge (per project policy)
+
+---
+
+### Package Publishing
+
+- [ ] GitHub **Release** with tag **`v0.11.1`** targeting **`release/v0.11.1`** (not `main` until versions exist on that branch)
+- [ ] CI **Test and Publish** workflow green; both packages at **0.11.1** / **0.2.13**
+- [ ] Confirm **`latest`** dist-tags on GitHub Packages if policy requires a manual check
+
+```bash
+# Example after publish — use exact versions from the Overview table
+npm dist-tag add @signal-meaning/voice-agent-react@0.11.1 latest --registry https://npm.pkg.github.com
+npm dist-tag add @signal-meaning/voice-agent-backend@0.2.13 latest --registry https://npm.pkg.github.com
+```
+
+---
+
+### Post-Release
+
+- [ ] PR **merge `release/v0.11.1` → `main`** (or documented fast-forward)
+- [ ] Close **GitHub #571** with resolution summary
+- [ ] Sync [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** if you keep issue folders aligned with GitHub
+
+---
+
+### Completion Criteria
+
+- [ ] Lint + `test:mock` + targeted tests above green; full `npm test` green if used as bar
+- [ ] Real-API integration and/or OpenAI E2E slice run when qualifying proxy relay behavior (document exceptions on #571)
+- [ ] `docs/releases/v0.11.1/` validated
+- [ ] Packages published from **`release/v0.11.1`** / tag **`v0.11.1`**
+- [ ] **`release/v0.11.1`** merged to **`main`**; **#571** closed
+
+---
+
+### References
+
+- [README.md](./README.md) — defect description and code pointers
+- [CURRENT-STATUS.md](./CURRENT-STATUS.md) — implementation snapshot
+- [NEXT-STEP.md](./NEXT-STEP.md) — PR / close-out
+- [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)
+- [docs/development/TEST-STRATEGY.md](../../development/TEST-STRATEGY.md)

--- a/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
@@ -31,7 +31,8 @@
 
 _(Fill in as you execute the release.)_
 
-- **Pre-publish:** _dates / PR / branch_
+- **PR (fix + docs):** [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) — **issue-571** → **main**, **Closes #571** (opened **2026-04-10**).
+- **Pre-publish:** _after merge: version bump + `docs/releases/v0.11.1/` on **release/v0.11.1**_
 - **Qualification:** _OpenAI proxy integration / E2E slice if run_
 - **Publish:** _GitHub Release ref, workflow run URL_
 - **Post-release:** _merge `release/v0.11.1` → `main`, close #571, sync issue docs_

--- a/docs/issues/ISSUE-571/TRACKING.md
+++ b/docs/issues/ISSUE-571/TRACKING.md
@@ -1,0 +1,15 @@
+# Issue #571 — Tracking
+
+Use this checklist while working [GitHub #571](https://github.com/Signal-Meaning/dg_react_agent/issues/571). Update checkboxes in the PR or here as work completes.
+
+## TDD / implementation
+
+- [ ] **RED:** Failing test that sends a client message before upstream `open` and expects it on the upstream side after connect (attach-upgrade / `createOpenAIWss`).
+- [ ] **GREEN:** Queue + flush in `createOpenAIWss` (`packages/voice-agent-backend/src/attach-upgrade.js`), matching `createDeepgramWss` semantics (`data`, `isBinary`).
+- [ ] **REFACTOR:** Share small helper or keep duplication minimal per existing style; ensure `close`/`error` paths remain correct if handlers move outside `upstream.on('open')`.
+- [ ] All relevant **`npm test`** (voice-agent-backend / root Jest) green locally.
+
+## Review / close-out
+
+- [ ] PR links **#571** (closes or fixes).
+- [ ] If release-worthy: version/changelog per package maintainer process; run any required real-API qualification for proxy changes.

--- a/docs/issues/ISSUE-571/TRACKING.md
+++ b/docs/issues/ISSUE-571/TRACKING.md
@@ -4,10 +4,10 @@ Use this checklist while working [GitHub #571](https://github.com/Signal-Meaning
 
 ## TDD / implementation
 
-- [ ] **RED:** Failing test that sends a client message before upstream `open` and expects it on the upstream side after connect (attach-upgrade / `createOpenAIWss`).
-- [ ] **GREEN:** Queue + flush in `createOpenAIWss` (`packages/voice-agent-backend/src/attach-upgrade.js`), matching `createDeepgramWss` semantics (`data`, `isBinary`).
-- [ ] **REFACTOR:** Share small helper or keep duplication minimal per existing style; ensure `close`/`error` paths remain correct if handlers move outside `upstream.on('open')`.
-- [ ] All relevant **`npm test`** (voice-agent-backend / root Jest) green locally.
+- [x] **RED:** Failing test that sends a client message before upstream `open` and expects it on the upstream side after connect (attach-upgrade / `createOpenAIWss`).
+- [x] **GREEN:** Queue + flush in `createOpenAIWss` (`packages/voice-agent-backend/src/attach-upgrade.js`), matching `createDeepgramWss` semantics (`data`, `isBinary`).
+- [x] **REFACTOR:** Minimal change; `clientWs` close/error registered before upstream `open`; single `upstream.on('error')` for log + `clientWs.close()`.
+- [x] **`npm test`** — `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js` and `tests/voice-agent-backend-attach-upgrade-upstream.test.ts` green.
 
 ## Review / close-out
 

--- a/packages/voice-agent-backend/src/attach-upgrade.js
+++ b/packages/voice-agent-backend/src/attach-upgrade.js
@@ -188,13 +188,35 @@ function createOpenAIWss(options) {
   wss.on('connection', (clientWs, req) => {
     const query = req?.url?.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
     const upstream = new WebSocket(proxyUrl + query, upstreamOptions);
+    /** Issue #571: client may send Settings (or audio) before upstream is OPEN; queue like createDeepgramWss. */
+    const messageQueue = [];
+
+    clientWs.on('message', (data, isBinary) => {
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data, { binary: isBinary });
+      } else {
+        messageQueue.push({ data, isBinary });
+      }
+    });
+
+    clientWs.on('close', () => {
+      if (upstream.readyState === WebSocket.CONNECTING || upstream.readyState === WebSocket.OPEN) {
+        upstream.close();
+      }
+    });
+    clientWs.on('error', () => {
+      if (upstream.readyState === WebSocket.CONNECTING || upstream.readyState === WebSocket.OPEN) {
+        upstream.close();
+      }
+    });
+
     upstream.on('open', () => {
-      clientWs.on('message', (data, isBinary) => upstream.send(data, { binary: isBinary }));
+      while (messageQueue.length > 0) {
+        const { data, isBinary } = messageQueue.shift();
+        upstream.send(data, { binary: isBinary });
+      }
       upstream.on('message', (data, isBinary) => clientWs.send(data, { binary: isBinary }));
-      clientWs.on('close', () => upstream.close());
       upstream.on('close', () => clientWs.close());
-      clientWs.on('error', () => upstream.close());
-      upstream.on('error', () => clientWs.close());
     });
     upstream.on('error', (err) => {
       log.error('[Proxy] OpenAI upstream error', errorAttrs(err));

--- a/tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js
+++ b/tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js
@@ -1,0 +1,150 @@
+/** @jest-environment node */
+
+/**
+ * Issue #571: createOpenAIWss must queue client→upstream frames until upstream is OPEN.
+ * Uses delayed upstream handshake (ws verifyClient async) so the relay client can send
+ * while the relay→upstream socket is still CONNECTING.
+ */
+
+const path = require('path');
+const http = require('http');
+const WebSocket = require('ws');
+const WebSocketServer = require('ws').WebSocketServer;
+
+const attachUpgradePath = path.resolve(__dirname, '../packages/voice-agent-backend/src/attach-upgrade.js');
+
+describe('createOpenAIWss client message queue (Issue #571)', () => {
+  jest.setTimeout(20000);
+
+  let upstreamWss = null;
+  let relayHttp = null;
+  let releaseUpstreamHandshake = null;
+  /** @type {import('ws')|null} */
+  let activeClient = null;
+
+  afterEach(async () => {
+    if (activeClient) {
+      try {
+        activeClient.terminate();
+      } catch (_) {
+        /* ignore */
+      }
+      activeClient = null;
+    }
+    if (relayHttp) {
+      relayHttp.closeAllConnections?.();
+    }
+    if (upstreamWss && upstreamWss._server) {
+      upstreamWss._server.closeAllConnections?.();
+    }
+    await new Promise((resolve) => {
+      if (relayHttp) relayHttp.close(() => resolve());
+      else resolve();
+    });
+    await new Promise((resolve) => {
+      if (upstreamWss) upstreamWss.close(() => resolve());
+      else resolve();
+    });
+    relayHttp = null;
+    upstreamWss = null;
+    releaseUpstreamHandshake = null;
+  });
+
+  /**
+   * @returns {Promise<{ relayPort: number, relayPath: string, upstreamVerifyInvoked: Promise<void> }>}
+   */
+  async function setupRelayWithDelayedUpstream() {
+    const upstreamPath = '/upstream-ws-571';
+    let verifiedCb = null;
+    /** Resolves when the upstream server has received the relay upgrade (verifyClient) — still CONNECTING until cb(true). */
+    let notifyUpstreamVerifyInvoked = () => {};
+    const upstreamVerifyInvoked = new Promise((resolve) => {
+      notifyUpstreamVerifyInvoked = resolve;
+    });
+
+    upstreamWss = new WebSocketServer({
+      port: 0,
+      host: '127.0.0.1',
+      path: upstreamPath,
+      verifyClient: (info, cb) => {
+        verifiedCb = cb;
+        notifyUpstreamVerifyInvoked();
+      },
+    });
+
+    await new Promise((resolve, reject) => {
+      upstreamWss.once('listening', resolve);
+      upstreamWss.once('error', reject);
+    });
+
+    const upstreamPort = upstreamWss.address().port;
+    releaseUpstreamHandshake = () => {
+      if (verifiedCb) verifiedCb(true);
+      verifiedCb = null;
+    };
+
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const { createOpenAIWss } = require(attachUpgradePath);
+    const proxyUrl = `ws://127.0.0.1:${upstreamPort}${upstreamPath}`;
+    const relayPath = '/relay-openai-571';
+    const { wss: relayWss } = createOpenAIWss({ path: relayPath, proxyUrl });
+
+    relayHttp = http.createServer();
+    relayHttp.on('upgrade', (req, socket, head) => {
+      const pathname = req.url.split('?')[0];
+      if (pathname === relayPath) {
+        relayWss.handleUpgrade(req, socket, head, (ws) => relayWss.emit('connection', ws, req));
+      } else {
+        socket.destroy();
+      }
+    });
+
+    await new Promise((resolve, reject) => {
+      relayHttp.listen(0, '127.0.0.1', () => resolve());
+      relayHttp.once('error', reject);
+    });
+
+    const relayPort = relayHttp.address().port;
+    return { relayPort, relayPath, upstreamVerifyInvoked };
+  }
+
+  it(
+    'forwards a client JSON frame sent before upstream WebSocket handshake completes',
+    async () => {
+      const { relayPort, relayPath, upstreamVerifyInvoked } = await setupRelayWithDelayedUpstream();
+
+      const upstreamMessage = new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error('upstream did not receive message within 8s')), 8000);
+        upstreamWss.once('connection', (ws) => {
+          ws.once('message', (data) => {
+            clearTimeout(t);
+            resolve(data.toString());
+          });
+        });
+      });
+
+      activeClient = new WebSocket(`ws://127.0.0.1:${relayPort}${relayPath}`);
+      const client = activeClient;
+      await new Promise((resolve, reject) => {
+        client.once('open', resolve);
+        client.once('error', reject);
+      });
+
+      await upstreamVerifyInvoked;
+
+      const payload = JSON.stringify({ type: 'Settings', issue: 571 });
+      client.send(payload);
+
+      await new Promise((r) => setImmediate(r));
+
+      releaseUpstreamHandshake();
+
+      const received = await upstreamMessage;
+      expect(received).toBe(payload);
+
+      client.close();
+      await new Promise((r) => setTimeout(r, 50));
+    },
+    15000
+  );
+});


### PR DESCRIPTION
## Summary

`createOpenAIWss` (`packages/voice-agent-backend/src/attach-upgrade.js`) now registers `clientWs.on('message')` immediately and queues frames until `upstream` is `OPEN`, then drains the queue on `open` — matching `createDeepgramWss`. Prevents **Settings** (and other early frames) from being dropped when the client WebSocket is already open but the relay→translator socket is still connecting.

Also registers early `clientWs` close/error handlers to tear down a `CONNECTING` upstream.

## Docs

- `docs/issues/ISSUE-571/` — README, CURRENT-STATUS, NEXT-STEP, TRACKING, **RELEASE-CHECKLIST** for patch **v0.11.1** / backend **0.2.13**.

## Test plan

- [x] `npm run lint` and `npm run test:mock`
- [x] `npm test -- tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js tests/voice-agent-backend-attach-upgrade-upstream.test.ts`

Closes #571

Made with [Cursor](https://cursor.com)