### PR TITLE
chore: merge release v0.11.1 (patch — #571 backend 0.2.13)

### DIFF
--- a/docs/issues/ISSUE-571/CURRENT-STATUS.md
+++ b/docs/issues/ISSUE-571/CURRENT-STATUS.md
@@ -2,9 +2,9 @@
 
 **Last updated:** 2026-04-10
 
-**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) — **open** (close after fix merged and tests green)
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) — **closed** (merged with [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572))
 
-**Branch:** `issue-571`
+**Branches:** **`main`** — fix + test; **`release/v0.11.1`** — **0.11.1** / **0.2.13** + `docs/releases/v0.11.1/` for npm publish
 
 ---
 
@@ -15,7 +15,7 @@
 | **Bug (historical)** | `createOpenAIWss` used to register `clientWs.on('message')` only inside `upstream.on('open')`; frames sent before upstream was open were **dropped**. |
 | **Impact** | Early **Settings** could be lost → translator never applies session → audio stuck in `pendingAudioQueue`; no agent response. |
 | **Reference implementation** | `createDeepgramWss` in the same file (`attach-upgrade.js`) queues client → upstream until upstream is `OPEN`. |
-| **Fix** | **On `issue-571`:** client→upstream `messageQueue`, immediate `clientWs.on('message')`, flush on `upstream.on('open')`; early `clientWs` close/error tears down upstream (`CONNECTING` \| `OPEN`). |
+| **Fix** | **On `main` (PR #572):** client→upstream `messageQueue`, immediate `clientWs.on('message')`, flush on `upstream.on('open')`; early `clientWs` close/error tears down upstream (`CONNECTING` \| `OPEN`). |
 | **Tests** | `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js` — delayed upstream `verifyClient` so client sends while relay→upstream is still held. |
 
 ---

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -1,27 +1,30 @@
 # Issue #571 — next step
 
-**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) (**closed**); fix [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) on **`main`**.
 
 ---
 
-## Done (this slice)
+## Done
 
-- Branch **`issue-571`** and docs under `docs/issues/ISSUE-571/`.
-- **TDD:** `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js` (delayed upstream `verifyClient` + `upstreamVerifyInvoked` so the client send races ahead of `cb(true)`).
-- **Implementation:** `packages/voice-agent-backend/src/attach-upgrade.js` — `createOpenAIWss` queues client→upstream until `upstream` is `OPEN`, mirrors Deepgram pattern; teardown if client disconnects while upstream is still connecting.
+- Branch **`issue-571`**, PR **#572**, merge to **`main`**, issue **#571** closed.
+- **TDD + implementation:** `attach-upgrade.js` queue, `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`.
+- **Release prep on `release/v0.11.1`:** Root **0.11.1**, backend **0.2.13**, `docs/releases/v0.11.1/` (`CHANGELOG`, `PACKAGE-STRUCTURE`, `RELEASE-NOTES`), `npm run validate:release-docs 0.11.1`, lint, audit, `test:mock`, targeted Jest (see [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md) Progress).
 
 ---
 
-## Recommended follow-ups
+## Recommended follow-ups (publish)
 
-1. **PR** — **[#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572)** (`issue-571` → `main`, **Closes #571**). Review and merge.
-2. **Patch release** — After merge, follow [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md): **v0.11.1** + **@signal-meaning/voice-agent-backend 0.2.13** (or document a backend-only exception on #571 per [PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)).
-3. **Qualification** — Real-API integration and/or OpenAI proxy E2E slice when qualifying relay timing (see checklist and [.cursorrules](../../../.cursorrules)).
-4. **Close issue** — After merge and publish, close #571 on GitHub and set [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** in a small doc commit if you keep issue folders in sync with GitHub.
+1. **Push** `git push -u origin release/v0.11.1`
+2. **GitHub Release** — Tag **`v0.11.1`**, target branch **`release/v0.11.1`** (not `main` until versions exist on that branch). See [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md).
+3. **CI** — Confirm **Test and Publish** green; **`latest`** on GitHub Packages if you verify manually.
+4. **Optional qualification** — With `OPENAI_API_KEY`: `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`; from `test-app`, OpenAI E2E slice per checklist.
+5. **Mergeback** — PR **`release/v0.11.1` → `main`** so published versions and `docs/releases/v0.11.1/` land on **`main`**.
+6. **Issue docs** — [README](./README.md) / [CURRENT-STATUS](./CURRENT-STATUS.md) already reflect **closed** and release branch; refresh [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md) checkboxes after publish.
 
 ---
 
 ## References
 
-- [README.md](./README.md) — problem statement and file pointers.
-- [TRACKING.md](./TRACKING.md) — checkbox TDD list.
+- [README.md](./README.md) — defect description and file pointers.
+- [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md) — full release checklist.
+- [TRACKING.md](./TRACKING.md) — TDD checklist (complete).

--- a/docs/issues/ISSUE-571/NEXT-STEP.md
+++ b/docs/issues/ISSUE-571/NEXT-STEP.md
@@ -14,7 +14,7 @@
 
 ## Recommended follow-ups (publish)
 
-1. **Push** `git push -u origin release/v0.11.1`
+1. **Push** — completed **2026-04-10** (`origin/release/v0.11.1`).
 2. **GitHub Release** — Tag **`v0.11.1`**, target branch **`release/v0.11.1`** (not `main` until versions exist on that branch). See [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md).
 3. **CI** — Confirm **Test and Publish** green; **`latest`** on GitHub Packages if you verify manually.
 4. **Optional qualification** — With `OPENAI_API_KEY`: `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`; from `test-app`, OpenAI E2E slice per checklist.

--- a/docs/issues/ISSUE-571/README.md
+++ b/docs/issues/ISSUE-571/README.md
@@ -1,10 +1,10 @@
 # Issue #571 — OpenAI relay drops pre-upstream-open client messages
 
-**Status:** Open on GitHub — **fix + tests on branch `issue-571`** (queue in `createOpenAIWss`); pending PR / merge / close.
+**Status:** GitHub [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) **closed** (**2026-04-10**); fix merged via [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572). Patch **v0.11.1** / **@signal-meaning/voice-agent-backend@0.2.13** — version + `docs/releases/v0.11.1/` on branch **`release/v0.11.1`** (push, GitHub Release, CI publish, then mergeback per [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md)).
 
 **GitHub:** [#571 — OpenAI relay (createOpenAIWss) drops client messages until upstream opens — queue like Deepgram path](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
 
-**Branch:** `issue-571`
+**Branches:** **`main`** has the code fix; **`release/v0.11.1`** carries semver + release docs for publish.
 
 ---
 
@@ -23,9 +23,9 @@ The translator (`scripts/openai-proxy/server.ts`) expects Settings to drive `ses
 
 Direct test-app → translator connections avoid the relay race; **browser → backend forwarder → translator** does not.
 
-## Proposed fix
+## Proposed fix (delivered)
 
-Mirror the Deepgram pattern in `createOpenAIWss`:
+Mirror the Deepgram pattern in `createOpenAIWss` (**shipped in backend 0.2.13**, PR **#572**):
 
 1. Register `clientWs.on('message')` as soon as the client connection is accepted.
 2. If `upstream.readyState !== WebSocket.OPEN`, push `{ data, isBinary }` to a queue.

--- a/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
@@ -31,7 +31,7 @@
 
 - **PR (fix + docs):** [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) — merged to **`main`** **2026-04-10** (**Closes #571**).
 - **Release branch prep (2026-04-10):** Branch **`release/v0.11.1`** from **`main`** with version bumps (**0.11.1** / **0.2.13**) and **`docs/releases/v0.11.1/`**; `npm run validate:release-docs 0.11.1`; `npm audit --audit-level=high`; `npm run lint`; `npm run test:mock`; targeted Jest (`#571` test, attach-upgrade, `openai-proxy-event-coverage`).
-- **Pre-publish:** _Push **`release/v0.11.1`**, then GitHub **Release** tag **`v0.11.1`** → CI **Test and Publish**_
+- **Pre-publish:** **`release/v0.11.1`** pushed **2026-04-10** — next: GitHub **Release** tag **`v0.11.1`** → CI **Test and Publish**
 - **Qualification (optional before publish):** `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`; OpenAI E2E slice from `test-app` when keys and servers available
 - **Publish:** _GitHub Release ref, workflow run URL_
 - **Post-release:** _PR merge **`release/v0.11.1` → `main`**_
@@ -91,7 +91,7 @@
 ### Git Operations
 
 - [x] Branch **`release/v0.11.1`** from **`main`** including version bumps + `docs/releases/v0.11.1/` + doc updates under `docs/issues/ISSUE-571/`
-- [ ] Push: `git push -u origin release/v0.11.1`
+- [x] Push: `git push -u origin release/v0.11.1` — **2026-04-10**
 - [ ] **Do not delete** `release/v0.11.1` after merge (per project policy)
 
 ---

--- a/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
+++ b/docs/issues/ISSUE-571/RELEASE-CHECKLIST.md
@@ -1,12 +1,12 @@
 # Issue #571: Release checklist — patch (backend relay fix)
 
-**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571)
+**GitHub:** [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) — **closed** when [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) merged (**2026-04-10**).
 
 **Scope:** Patch shipping **Issue #571** — `createOpenAIWss` queues client→upstream WebSocket frames until the upstream socket is `OPEN` (matches `createDeepgramWss`). Fixes lost **Settings** when the browser connects through the Express relay before the translator handshake completes.
 
-**Authoritative checklist:** Mirror [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md) on the GitHub release issue (if you open one) or on **#571**. This file is the **repo-local** companion: versions, paths, and commands.
+**Authoritative checklist:** Mirror [.github/ISSUE_TEMPLATE/release-checklist.md](../../../.github/ISSUE_TEMPLATE/release-checklist.md) on the GitHub release issue (if you open one). This file is the **repo-local** companion: versions, paths, and commands.
 
-**Publishing note:** Per [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md), the GitHub Release tag **`vX.X.X`** follows the **root** component version. This checklist assumes a **coordinated patch**: bump **both** packages so tag **`v0.11.1`** matches root **`0.11.1`** and **`@signal-meaning/voice-agent-backend`** ships **`0.2.13`**. If you intentionally ship **backend only**, document that on #571 and adjust branch/tag steps with maintainers (CI publishes both packages when the workflow runs).
+**Publishing note:** Per [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md), the GitHub Release tag **`vX.X.X`** follows the **root** component version. This checklist uses a **coordinated patch**: bump **both** packages so tag **`v0.11.1`** matches root **`0.11.1`** and **`@signal-meaning/voice-agent-backend`** ships **`0.2.13`**.
 
 ---
 
@@ -25,60 +25,59 @@
 
 **CHANGELOG entry (Issue #571):** Patch release — OpenAI relay (`createOpenAIWss` in `packages/voice-agent-backend/src/attach-upgrade.js`) queues client messages until upstream WebSocket is open, preventing dropped **Settings** and stuck sessions when clients use the backend upgrade path (browser → relay → translator). Regression test: `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`.
 
-**Documentation set (patch):** `docs/releases/v0.11.1/` — `CHANGELOG.md`, `PACKAGE-STRUCTURE.md` (from [docs/releases/PACKAGE-STRUCTURE.template.md](../../releases/PACKAGE-STRUCTURE.template.md)), optional `RELEASE-NOTES.md`. No `MIGRATION.md` unless a breaking change is discovered.
+**Documentation set (patch):** `docs/releases/v0.11.1/` — `CHANGELOG.md`, `PACKAGE-STRUCTURE.md`, `RELEASE-NOTES.md`.
 
 ### Progress
 
-_(Fill in as you execute the release.)_
-
-- **PR (fix + docs):** [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) — **issue-571** → **main**, **Closes #571** (opened **2026-04-10**).
-- **Pre-publish:** _after merge: version bump + `docs/releases/v0.11.1/` on **release/v0.11.1**_
-- **Qualification:** _OpenAI proxy integration / E2E slice if run_
+- **PR (fix + docs):** [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) — merged to **`main`** **2026-04-10** (**Closes #571**).
+- **Release branch prep (2026-04-10):** Branch **`release/v0.11.1`** from **`main`** with version bumps (**0.11.1** / **0.2.13**) and **`docs/releases/v0.11.1/`**; `npm run validate:release-docs 0.11.1`; `npm audit --audit-level=high`; `npm run lint`; `npm run test:mock`; targeted Jest (`#571` test, attach-upgrade, `openai-proxy-event-coverage`).
+- **Pre-publish:** _Push **`release/v0.11.1`**, then GitHub **Release** tag **`v0.11.1`** → CI **Test and Publish**_
+- **Qualification (optional before publish):** `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`; OpenAI E2E slice from `test-app` when keys and servers available
 - **Publish:** _GitHub Release ref, workflow run URL_
-- **Post-release:** _merge `release/v0.11.1` → `main`, close #571, sync issue docs_
+- **Post-release:** _PR merge **`release/v0.11.1` → `main`**_
 
 ---
 
 ### Pre-merge (before `release/v0.11.1`)
 
-- [ ] **#571 fix on `main`:** PR merged that contains the queue fix + Jest test (or equivalent), linked to **#571**.
-- [ ] **Code review complete** on the merge commit that will be released.
+- [x] **#571 fix on `main`:** [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) merged (queue fix + Jest test).
+- [x] **Code review complete** on #572.
 
 ---
 
 ### Pre-Release Preparation
 
-- [ ] **Tests passing**
-  - [ ] **CI bar:** `npm run lint` then `npm run test:mock`
-  - [ ] **Issue #571 unit test:** `npm test -- tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`
-  - [ ] **Attach-upgrade / #441:** `npm test -- tests/voice-agent-backend-attach-upgrade-upstream.test.ts`
+- [x] **Tests passing** _(release bar on **`release/v0.11.1`**, 2026-04-10)_
+  - [x] **CI bar:** `npm run lint` then `npm run test:mock`
+  - [x] **Issue #571 unit test:** `npm test -- tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`
+  - [x] **Attach-upgrade / #441:** `npm test -- tests/voice-agent-backend-attach-upgrade-upstream.test.ts`
   - [ ] **Full Jest (recommended):** `npm test`
-  - [ ] **Relay / proxy timing (recommended when `OPENAI_API_KEY` available):**  
+  - [ ] **Relay / proxy timing (when `OPENAI_API_KEY` available):**  
     `USE_REAL_APIS=1 npm test -- tests/integration/openai-proxy-integration.test.ts`
-  - [ ] **Upstream event coverage:** `npm test -- tests/openai-proxy-event-coverage.test.ts`
+  - [x] **Upstream event coverage:** `npm test -- tests/openai-proxy-event-coverage.test.ts`
   - [ ] **OpenAI proxy E2E slice (recommended):** from **`test-app`**, with backend + dev server running (`npm run backend`, `npm run dev`), e.g.  
     `E2E_USE_EXISTING_SERVER=1 USE_PROXY_MODE=true E2E_USE_HTTP=1 USE_REAL_APIS=1 npm run test:e2e:openai`  
     See [test-app/tests/e2e/README.md](../../../test-app/tests/e2e/README.md).
-- [ ] **Linting clean:** `npm run lint`
-- [ ] **npm audit:** `npm audit --audit-level=high` — exit 0
-- [ ] **Breaking changes:** None expected; if any surface, document in `docs/API-REFERENCE.md` and release notes
+- [x] **Linting clean:** `npm run lint`
+- [x] **npm audit:** `npm audit --audit-level=high` — exit 0
+- [x] **Breaking changes:** None; no `MIGRATION.md`
 
 ---
 
 ### Version Management
 
-- [ ] Root `package.json` (and root lockfile if applicable) → **0.11.1**
-- [ ] `packages/voice-agent-backend/package.json` → **0.2.13**
-- [ ] Any workspace consumer that pins backend (e.g. test-app) updated if your policy requires a strict range bump
+- [x] Root `package.json` → **0.11.1** _(root `package-lock.json` unchanged — no workspace pin of backend version)_
+- [x] `packages/voice-agent-backend/package.json` → **0.2.13**
+- [x] **test-app:** uses `../packages/voice-agent-backend` via npm scripts — **no** `package.json` range bump required
 
 ---
 
 ### Documentation (`docs/releases/v0.11.1/`)
 
-- [ ] `CHANGELOG.md` — link **#571**; describe relay queue fix
-- [ ] `PACKAGE-STRUCTURE.md` — from template; placeholders for **0.11.1**
-- [ ] Optional: `RELEASE-NOTES.md`
-- [ ] Validate: `npm run validate:release-docs 0.11.1`
+- [x] `CHANGELOG.md` — links **#571**, **#572**; relay queue fix
+- [x] `PACKAGE-STRUCTURE.md` — **v0.11.1** / backend **0.2.13** (no `vX.X.X` placeholders)
+- [x] `RELEASE-NOTES.md`
+- [x] Validate: `npm run validate:release-docs 0.11.1`
 
 ---
 
@@ -91,7 +90,7 @@ _(Fill in as you execute the release.)_
 
 ### Git Operations
 
-- [ ] Branch **`release/v0.11.1`** from the commit that includes version bumps + `docs/releases/v0.11.1/`
+- [x] Branch **`release/v0.11.1`** from **`main`** including version bumps + `docs/releases/v0.11.1/` + doc updates under `docs/issues/ISSUE-571/`
 - [ ] Push: `git push -u origin release/v0.11.1`
 - [ ] **Do not delete** `release/v0.11.1` after merge (per project policy)
 
@@ -99,7 +98,7 @@ _(Fill in as you execute the release.)_
 
 ### Package Publishing
 
-- [ ] GitHub **Release** with tag **`v0.11.1`** targeting **`release/v0.11.1`** (not `main` until versions exist on that branch)
+- [ ] GitHub **Release** with tag **`v0.11.1`** targeting **`release/v0.11.1`**
 - [ ] CI **Test and Publish** workflow green; both packages at **0.11.1** / **0.2.13**
 - [ ] Confirm **`latest`** dist-tags on GitHub Packages if policy requires a manual check
 
@@ -113,19 +112,18 @@ npm dist-tag add @signal-meaning/voice-agent-backend@0.2.13 latest --registry ht
 
 ### Post-Release
 
-- [ ] PR **merge `release/v0.11.1` → `main`** (or documented fast-forward)
-- [ ] Close **GitHub #571** with resolution summary
-- [ ] Sync [README.md](./README.md) / [CURRENT-STATUS.md](./CURRENT-STATUS.md) to **Closed** if you keep issue folders aligned with GitHub
+- [ ] PR **merge `release/v0.11.1` → `main`** (brings version bumps + `docs/releases/` onto `main` after publish)
+- [x] **GitHub #571** — **closed** on #572 merge (no further action)
 
 ---
 
 ### Completion Criteria
 
-- [ ] Lint + `test:mock` + targeted tests above green; full `npm test` green if used as bar
-- [ ] Real-API integration and/or OpenAI E2E slice run when qualifying proxy relay behavior (document exceptions on #571)
-- [ ] `docs/releases/v0.11.1/` validated
+- [x] Lint + `test:mock` + targeted proxy tests green on release branch _(full `npm test` optional)_
+- [ ] Real-API integration and/or OpenAI E2E slice _(document exception on release issue if skipped)_
+- [x] `docs/releases/v0.11.1/` validated
 - [ ] Packages published from **`release/v0.11.1`** / tag **`v0.11.1`**
-- [ ] **`release/v0.11.1`** merged to **`main`**; **#571** closed
+- [ ] **`release/v0.11.1`** merged to **`main`**
 
 ---
 
@@ -133,6 +131,6 @@ npm dist-tag add @signal-meaning/voice-agent-backend@0.2.13 latest --registry ht
 
 - [README.md](./README.md) — defect description and code pointers
 - [CURRENT-STATUS.md](./CURRENT-STATUS.md) — implementation snapshot
-- [NEXT-STEP.md](./NEXT-STEP.md) — PR / close-out
+- [NEXT-STEP.md](./NEXT-STEP.md) — publish / mergeback
 - [docs/PUBLISHING-AND-RELEASING.md](../../PUBLISHING-AND-RELEASING.md)
 - [docs/development/TEST-STRATEGY.md](../../development/TEST-STRATEGY.md)

--- a/docs/issues/ISSUE-571/TRACKING.md
+++ b/docs/issues/ISSUE-571/TRACKING.md
@@ -11,5 +11,6 @@ Use this checklist while working [GitHub #571](https://github.com/Signal-Meaning
 
 ## Review / close-out
 
-- [ ] PR links **#571** (closes or fixes).
-- [ ] If release-worthy: version/changelog per package maintainer process; run any required real-API qualification for proxy changes.
+- [x] PR [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) merged; **#571** closed.
+- [ ] **Publish:** `release/v0.11.1` → GitHub Release **v0.11.1** → CI → mergeback to `main` ([RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md)).
+- [ ] Optional: real-API integration / OpenAI E2E slice before or after publish per policy.

--- a/docs/releases/v0.11.1/CHANGELOG.md
+++ b/docs/releases/v0.11.1/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog - v0.11.1
+
+**Release Date:** April 2026  
+**Release Type:** Patch Release
+
+All changes in this release are documented here. [Keep a Changelog](https://keepachangelog.com/) format.
+
+## Fixed
+
+- **@signal-meaning/voice-agent-backend 0.2.13 (Issue [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571), PR [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572)):** OpenAI relay **`createOpenAIWss`** (`packages/voice-agent-backend/src/attach-upgrade.js`) now **queues** client→upstream WebSocket frames until the upstream socket is **`OPEN`**, matching **`createDeepgramWss`**. Prevents **Settings** (and other early frames) from being dropped when the browser connects through the Express upgrade relay before the translator handshake completes (symptom: no `session.update`, audio stuck in `pendingAudioQueue`, no agent response). Regression test: `tests/voice-agent-backend-issue-571-createOpenAIWss-queue.test.js`.
+
+## Changed
+
+- **@signal-meaning/voice-agent-react** republished at **0.11.1** with the same component sources as **0.11.0** (release train with backend **0.2.13**).
+
+## Backward Compatibility
+
+- **Component public API:** Unchanged.
+- **Backend relay:** Integrators using **browser → `attachVoiceAgentUpgrade` OpenAI path → translator** should upgrade to **0.2.13** for the race fix; direct translator connections were unaffected.
+
+## References
+
+- Issue [#571](https://github.com/Signal-Meaning/dg_react_agent/issues/571) — defect analysis and checklist
+- PR [#572](https://github.com/Signal-Meaning/dg_react_agent/pull/572) — implementation merge to `main`

--- a/docs/releases/v0.11.1/PACKAGE-STRUCTURE.md
+++ b/docs/releases/v0.11.1/PACKAGE-STRUCTURE.md
@@ -1,0 +1,123 @@
+# Package Structure: @signal-meaning/voice-agent-react@v0.11.1
+
+Earlier releases were originally published under the package name `@signal-meaning/deepgram-voice-interaction-react`; the package has been renamed to `@signal-meaning/voice-agent-react`.
+
+**Backend package (same repo, separate publish):** `@signal-meaning/voice-agent-backend@0.2.13` — see `packages/voice-agent-backend/package.json` and README (OpenAI proxy; Issue **#571** relay queue fix in `attach-upgrade.js`).
+
+## Files Included in Package
+
+As defined in `package.json` "files" field:
+
+```
+signal-meaning-voice-agent-react-v0.11.1/
+├── dist/                      # Built component and utilities
+│   ├── index.js               # CommonJS entry point
+│   ├── index.esm.js           # ES Module entry point
+│   ├── index.d.ts             # TypeScript definitions
+│   ├── components/
+│   │   └── DeepgramVoiceInteraction/
+│   │       └── index.d.ts
+│   ├── constants/
+│   │   ├── documentation.d.ts
+│   │   └── vad-events.d.ts
+│   ├── hooks/
+│   │   └── useIdleTimeoutManager.d.ts
+│   ├── services/
+│   │   └── AgentStateService.d.ts
+│   ├── test-utils/
+│   │   ├── test-helpers.d.ts
+│   │   └── timeout-testing.d.ts
+│   ├── test-utils.d.ts
+│   ├── types/
+│   │   ├── agent.d.ts
+│   │   ├── connection.d.ts
+│   │   ├── index.d.ts
+│   │   ├── transcription.d.ts
+│   │   └── voiceBot.d.ts
+│   └── utils/
+│       ├── api-key-validator.d.ts
+│       ├── audio/
+│       │   ├── AudioManager.d.ts
+│       │   └── AudioUtils.d.ts
+│       ├── conversation-context.d.ts
+│       ├── IdleTimeoutService.d.ts
+│       ├── instructions-loader.d.ts
+│       ├── plugin-validator.d.ts
+│       ├── state/
+│       │   └── VoiceInteractionState.d.ts
+│       └── websocket/
+│           └── WebSocketManager.d.ts
+├── README.md                  # Package documentation
+├── DEVELOPMENT.md             # Development guide
+├── docs/                      # Documentation
+│   ├── releases/             # Release notes and migration guides
+│   │   └── v0.11.1/
+│   │       ├── CHANGELOG.md
+│   │       ├── RELEASE-NOTES.md
+│   │       └── PACKAGE-STRUCTURE.md
+│   ├── development/          # Development guides
+│   ├── issues/               # Issue documentation
+│   └── migration/            # Migration guides
+├── scripts/                   # Utility scripts
+│   ├── create-release-issue.sh
+│   ├── check-token-issues.js
+│   ├── validate-plugin.js
+│   ├── generate-test-audio.js
+│   └── [other scripts...]
+└── test-app/                 # Test application demonstrating component usage
+    ├── src/                  # Test app source code
+    │   ├── App.tsx           # Main test app component
+    │   ├── session-management.ts
+    │   └── [other files...]
+    ├── tests/                # E2E tests
+    │   ├── e2e/              # Playwright E2E tests
+    │   ├── unit/             # Unit tests
+    │   └── integration/      # Integration tests
+    ├── docs/                 # Test app documentation
+    └── [other files...]
+```
+
+## Package Entry Points
+
+From `package.json`:
+
+- **Main (CommonJS)**: `dist/index.js`
+- **Module (ESM)**: `dist/index.esm.js`
+- **Types**: `dist/index.d.ts`
+
+## Purpose of Each Directory
+
+- **`dist/`**: Built production code and TypeScript definitions
+- **`README.md`**: Package overview and quick start
+- **`DEVELOPMENT.md`**: Development setup and contribution guide
+- **`docs/`**: Comprehensive documentation (releases, guides, issues)
+- **`scripts/`**: Utility scripts for development and publishing
+- **`test-app/`**: Reference implementation and E2E test suite
+
+## Package Size Information
+
+Sizes are not recorded in-repo for this release; use `npm pack --dry-run` after `npm run build` if you need tarball metrics.
+
+## Installation
+
+```bash
+npm install @signal-meaning/voice-agent-react@v0.11.1
+```
+
+**Backend (OpenAI proxy, function-call routes):**
+
+```bash
+npm install @signal-meaning/voice-agent-backend@0.2.13
+```
+
+## Verification
+
+After installation, verify the package structure:
+
+```bash
+# Check installed files
+ls node_modules/@signal-meaning/voice-agent-react/
+
+# Verify entry points exist
+ls node_modules/@signal-meaning/voice-agent-react/dist/
+```

--- a/docs/releases/v0.11.1/RELEASE-NOTES.md
+++ b/docs/releases/v0.11.1/RELEASE-NOTES.md
@@ -1,0 +1,7 @@
+# Release Notes — v0.11.1
+
+**Packages:** `@signal-meaning/voice-agent-react@0.11.1`, `@signal-meaning/voice-agent-backend@0.2.13`
+
+Patch release: **OpenAI relay** (`createOpenAIWss`) queues client WebSocket messages until the upstream connection to the translator is open, fixing lost **Settings** on the relay hop (Issue **#571**, PR **#572**).
+
+Upgrade **`@signal-meaning/voice-agent-backend`** to **0.2.13** if you use the bundled upgrade proxy with OpenAI proxy mode. See [CHANGELOG.md](./CHANGELOG.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-meaning/voice-agent-react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A React component for real-time transcription and voice agent interactions using Deepgram APIs",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/voice-agent-backend/package.json
+++ b/packages/voice-agent-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-meaning/voice-agent-backend",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Backend and proxy package for Deepgram and OpenAI voice agent; mountable routes for test-app and voice-commerce.",
   "main": "src/index.js",
   "bin": { "voice-agent-backend": "src/cli.js" },


### PR DESCRIPTION
## Summary

Mergeback after **GitHub Release [v0.11.1](https://github.com/Signal-Meaning/dg_react_agent/releases/tag/v0.11.1)** (packages **@signal-meaning/voice-agent-react@0.11.1** and **@signal-meaning/voice-agent-backend@0.2.13**).

Brings version bumps and `docs/releases/v0.11.1/` onto `main`. The code fix for Issue **#571** is already on `main` via #572; this PR aligns `main` with published semver + release docs.

## Checklist

- [ ] Confirm **Test and Publish** workflow succeeded for tag **v0.11.1** before merging.
- [ ] Merge this PR after CI green (if branch protection runs on PR).

Related: #571, #572

Made with [Cursor](https://cursor.com)